### PR TITLE
[BUG] 노트 작성 문제 수정

### DIFF
--- a/core/common/src/main/java/com/teamwiney/core/common/model/WineSmell.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/model/WineSmell.kt
@@ -1,0 +1,23 @@
+package com.teamwiney.core.common.model
+
+enum class WineSmell(val type: String, val value: String, val korName: String) {
+    FRUIT("FRUIT", "FRUIT", "과일향"),
+    BERRY("FRUIT", "BERRY", "베리류"),
+    LEMONANDLIME("FRUIT", "LEMONANDLIME", "레몬/라임"),
+    APPLEPEAR("FRUIT", "APPLEPEAR", "사과/배"),
+    PEACHPLUM("FRUIT", "PEACHPLUM", "복숭아/자두"),
+    TROPICALFRUIT("FRUIT", "TROPICALFRUIT", "열대과일"),
+    FLOWER("NATURAL", "FLOWER", "꽃향"),
+    GRASSWOOD("NATURAL", "GRASSWOOD", "풀/나무"),
+    HERB("NATURAL", "HERB", "허브향"),
+    OAK("OAK", "OAK", "오크향"),
+    SPICE("OAK", "SPICE", "향신료"),
+    NUTS("OAK", "NUTS", "견과류"),
+    VANILLA("OAK", "VANILLA", "바닐라"),
+    CHOCOLATE("OAK", "CHOCOLATE", "초콜릿"),
+    FLINT("OTHER", "FLINT", "부싯돌"),
+    BREAD("OTHER", "BREAD", "빵"),
+    RUBBER("OTHER", "RUBBER", "고무"),
+    EARTHASH("OTHER", "EARTASH", "흙/재"),
+    MEDICINE("OTHER", "MEDICNE", "약품")
+}

--- a/data/src/main/java/com/teamwiney/data/datasource/TastingNoteDataSource.kt
+++ b/data/src/main/java/com/teamwiney/data/datasource/TastingNoteDataSource.kt
@@ -11,7 +11,6 @@ import com.teamwiney.data.network.model.response.TastingNoteIdRes
 import kotlinx.coroutines.flow.Flow
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
-import retrofit2.http.Part
 
 interface TastingNoteDataSource {
 
@@ -32,8 +31,7 @@ interface TastingNoteDataSource {
     fun deleteTastingNote(noteId: Int): Flow<ApiResult<ResponseWrapper<String>>>
 
     fun postTastingNote(
-        wineNoteWriteRequest: HashMap<String, RequestBody>,
-        smellKeywordList: List<MultipartBody.Part>,
+        request: RequestBody,
         multipartFiles: List<MultipartBody.Part>,
     ): Flow<ApiResult<ResponseWrapper<TastingNoteIdRes>>>
 }

--- a/data/src/main/java/com/teamwiney/data/datasource/TastingNoteDataSourceImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/datasource/TastingNoteDataSourceImpl.kt
@@ -66,17 +66,10 @@ class TastingNoteDataSourceImpl @Inject constructor(
         }.flowOn(ioDispatcher)
 
     override fun postTastingNote(
-        wineNoteWriteRequest: HashMap<String, RequestBody>,
-        smellKeywordList: List<MultipartBody.Part>,
+        request: RequestBody,
         multipartFiles: List<MultipartBody.Part>
     ): Flow<ApiResult<ResponseWrapper<TastingNoteIdRes>>> = flow {
-        emit(
-            tastingNoteService.postTastingNote(
-                wineNoteWriteRequest,
-                smellKeywordList,
-                multipartFiles
-            )
-        )
+        emit(tastingNoteService.postTastingNote(request, multipartFiles))
     }.flowOn(ioDispatcher)
 
 }

--- a/data/src/main/java/com/teamwiney/data/di/DataModule.kt
+++ b/data/src/main/java/com/teamwiney/data/di/DataModule.kt
@@ -1,5 +1,6 @@
 package com.teamwiney.data.di
 
+import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import com.teamwiney.data.datasource.AuthDataSource
@@ -22,6 +23,7 @@ import com.teamwiney.data.repository.wine.WineRepositoryImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Singleton
@@ -67,8 +69,9 @@ object DataModule {
     @Provides
     @Singleton
     fun providesTastingNotRepository(
-        tastingNoteDataSource: TastingNoteDataSource
-    ): TastingNoteRepository = TastingNoteRepositoryImpl(tastingNoteDataSource)
+        tastingNoteDataSource: TastingNoteDataSource,
+        @ApplicationContext context: Context
+    ): TastingNoteRepository = TastingNoteRepositoryImpl(tastingNoteDataSource, context)
 
     @Provides
     @Singleton

--- a/data/src/main/java/com/teamwiney/data/network/service/TastingNoteService.kt
+++ b/data/src/main/java/com/teamwiney/data/network/service/TastingNoteService.kt
@@ -16,10 +16,8 @@ import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
-import retrofit2.http.PartMap
 import retrofit2.http.Path
 import retrofit2.http.Query
-import java.util.PrimitiveIterator.OfInt
 
 interface TastingNoteService {
 
@@ -58,8 +56,7 @@ interface TastingNoteService {
     @Multipart
     @POST("/tasting-notes")
     suspend fun postTastingNote(
-        @PartMap wineNoteWriteRequest: HashMap<String, RequestBody>,
-        @Part smellKeywordList: List<MultipartBody.Part>,
+        @Part("request") request: RequestBody,
         @Part multipartFiles: List<MultipartBody.Part>,
     ): ApiResult<ResponseWrapper<TastingNoteIdRes>>
 }

--- a/data/src/main/java/com/teamwiney/data/repository/tastingnote/TastingNoteRepository.kt
+++ b/data/src/main/java/com/teamwiney/data/repository/tastingnote/TastingNoteRepository.kt
@@ -1,5 +1,6 @@
 package com.teamwiney.data.repository.tastingnote
 
+import android.net.Uri
 import com.teamwiney.core.common.base.ResponseWrapper
 import com.teamwiney.core.common.`typealias`.BaseResponse
 import com.teamwiney.data.network.adapter.ApiResult
@@ -10,8 +11,6 @@ import com.teamwiney.data.network.model.response.TastingNoteDetail
 import com.teamwiney.data.network.model.response.TastingNoteFilters
 import com.teamwiney.data.network.model.response.TastingNoteIdRes
 import kotlinx.coroutines.flow.Flow
-import okhttp3.MultipartBody
-import okhttp3.RequestBody
 
 interface TastingNoteRepository {
 
@@ -40,7 +39,21 @@ interface TastingNoteRepository {
     fun deleteTastingNote(noteId: Int): Flow<ApiResult<BaseResponse>>
 
     fun postTastingNote(
-        request: RequestBody,
-        multipartFiles: List<MultipartBody.Part>,
+        wineId: Long,
+        officialAlcohol: Double,
+        alcohol: Int,
+        color: String,
+        sweetness: Int,
+        acidity: Int,
+        body: Int,
+        tannin: Int,
+        finish: Int,
+        memo: String,
+        rating: Int,
+        vintage: String,
+        price: String,
+        buyAgain: Boolean?,
+        smellKeywordList: List<String>,
+        imgUris: List<Uri>
     ): Flow<ApiResult<ResponseWrapper<TastingNoteIdRes>>>
 }

--- a/data/src/main/java/com/teamwiney/data/repository/tastingnote/TastingNoteRepository.kt
+++ b/data/src/main/java/com/teamwiney/data/repository/tastingnote/TastingNoteRepository.kt
@@ -40,8 +40,7 @@ interface TastingNoteRepository {
     fun deleteTastingNote(noteId: Int): Flow<ApiResult<BaseResponse>>
 
     fun postTastingNote(
-        wineNoteWriteRequest: HashMap<String, RequestBody>,
-        smellKeywordList: List<MultipartBody.Part>,
+        request: RequestBody,
         multipartFiles: List<MultipartBody.Part>,
     ): Flow<ApiResult<ResponseWrapper<TastingNoteIdRes>>>
 }

--- a/data/src/main/java/com/teamwiney/data/repository/tastingnote/TastingNoteRepositoryImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/repository/tastingnote/TastingNoteRepositoryImpl.kt
@@ -50,14 +50,9 @@ class TastingNoteRepositoryImpl @Inject constructor(
         tastingNoteDataSource.deleteTastingNote(noteId)
 
     override fun postTastingNote(
-        wineNoteWriteRequest: HashMap<String, RequestBody>,
-        smellKeywordList: List<MultipartBody.Part>,
+        request: RequestBody,
         multipartFiles: List<MultipartBody.Part>
     ): Flow<ApiResult<ResponseWrapper<TastingNoteIdRes>>> {
-        return tastingNoteDataSource.postTastingNote(
-            wineNoteWriteRequest,
-            smellKeywordList,
-            multipartFiles
-        )
+        return tastingNoteDataSource.postTastingNote(request, multipartFiles)
     }
 }

--- a/data/src/main/java/com/teamwiney/data/repository/tastingnote/TastingNoteRepositoryImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/repository/tastingnote/TastingNoteRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.teamwiney.data.repository.tastingnote
 
+import android.content.Context
+import android.net.Uri
 import com.teamwiney.core.common.base.ResponseWrapper
 import com.teamwiney.core.common.`typealias`.BaseResponse
 import com.teamwiney.data.datasource.TastingNoteDataSource
@@ -10,13 +12,22 @@ import com.teamwiney.data.network.model.response.TastingNote
 import com.teamwiney.data.network.model.response.TastingNoteDetail
 import com.teamwiney.data.network.model.response.TastingNoteFilters
 import com.teamwiney.data.network.model.response.TastingNoteIdRes
+import com.teamwiney.data.util.fileFromContentUri
+import com.teamwiney.data.util.resizeAndSaveImage
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
 import javax.inject.Inject
 
 class TastingNoteRepositoryImpl @Inject constructor(
-    private val tastingNoteDataSource: TastingNoteDataSource
+    private val tastingNoteDataSource: TastingNoteDataSource,
+    @ApplicationContext private val context: Context
 ) : TastingNoteRepository {
 
     override fun getTasteAnalysis(): Flow<ApiResult<ResponseWrapper<TasteAnalysis>>> =
@@ -50,9 +61,49 @@ class TastingNoteRepositoryImpl @Inject constructor(
         tastingNoteDataSource.deleteTastingNote(noteId)
 
     override fun postTastingNote(
-        request: RequestBody,
-        multipartFiles: List<MultipartBody.Part>
+        wineId: Long,
+        officialAlcohol: Double,
+        alcohol: Int,
+        color: String,
+        sweetness: Int,
+        acidity: Int,
+        body: Int,
+        tannin: Int,
+        finish: Int,
+        memo: String,
+        rating: Int,
+        vintage: String,
+        price: String,
+        buyAgain: Boolean?,
+        smellKeywordList: List<String>,
+        imgUris: List<Uri>
     ): Flow<ApiResult<ResponseWrapper<TastingNoteIdRes>>> {
+        val jsonObjectBuilder = JSONObject().apply {
+            put("wineId", wineId)
+            put("officialAlcohol", officialAlcohol)
+            put("alcohol", alcohol)
+            put("color", color)
+            put("sweetness", sweetness)
+            put("acidity", acidity)
+            put("body", body)
+            put("tannin", tannin)
+            put("finish", finish)
+            put("memo", memo)
+            put("rating", rating)
+            if (vintage.isNotEmpty()) put("vintage", vintage.toInt())
+            if (price.isNotEmpty()) put("price", price.toInt())
+            buyAgain?.let { put("buyAgain", it) }
+            put("smellKeywordList", JSONArray().apply { smellKeywordList.forEach { put(it) } })
+        }
+
+        val request = jsonObjectBuilder.toString().toRequestBody("application/json".toMediaType())
+        val multipartFiles = imgUris.map {
+            val originalFile = fileFromContentUri(context, it)
+            val compressedFile = resizeAndSaveImage(context, originalFile)
+            val requestBody: RequestBody = compressedFile.asRequestBody("image/*".toMediaType())
+            MultipartBody.Part.createFormData("multipartFiles", compressedFile.name, requestBody)
+        }
+
         return tastingNoteDataSource.postTastingNote(request, multipartFiles)
     }
 }

--- a/data/src/main/java/com/teamwiney/data/util/FileExt.kt
+++ b/data/src/main/java/com/teamwiney/data/util/FileExt.kt
@@ -11,11 +11,9 @@ import java.security.SecureRandom
 import java.util.*
 
 fun fileFromContentUri(context: Context, contentUri: Uri): File {
-    // Preparing Temp file name
     val fileExtension = getFileExtension(context, contentUri)
     val fileName = "temp_file" + if (fileExtension != null) ".$fileExtension" else ""
 
-    // Creating Temp file
     val tempFile = File(context.cacheDir, fileName)
     tempFile.createNewFile()
 
@@ -97,7 +95,7 @@ private fun createFile(context: Context): File {
 
     val storageDir = context.cacheDir
 
-    return File(storageDir, fileName)
+    return File(storageDir, "${fileName}.jpg")
 }
 
 private fun generateRandomFileName(length: Int): String {

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoColorAndFlavorScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoColorAndFlavorScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,7 +18,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicTextField
@@ -61,15 +62,15 @@ import com.teamwiney.ui.components.WButton
 import com.teamwiney.ui.components.bottomBorder
 import com.teamwiney.ui.theme.LocalColors
 import com.teamwiney.ui.theme.WineyTheme
-import kotlinx.coroutines.Job
 
-data class WineSmell(
+data class WineSmellKeyword(
     val title: String,
     val options: List<WineSmellOption>,
 )
 
 data class WineSmellOption(
     val name: String,
+    val value: String,
     var isSelected: Boolean = false
 )
 
@@ -113,8 +114,9 @@ fun NoteWineInfoColorAndSmellScreen(
                 updateThumbX = { viewModel.updateThumbX(it) },
             ) { viewModel.updateColor(it) }
             HeightSpacer(35.dp)
-            WineFavorPicker(
-                wineSmells = uiState.wineSmells,
+            WineFlavorPicker(
+                wineSmellKeywords = uiState.wineSmellKeywords,
+                isWineSmellKeywordSelected = viewModel::isWineSmellSelected,
                 updateWineSmell = { wineSmellOption ->
                     viewModel.updateWineSmells(wineSmellOption)
                 },
@@ -146,8 +148,9 @@ fun NoteWineInfoColorAndSmellScreen(
 }
 
 @Composable
-private fun WineFavorPicker(
-    wineSmells: List<WineSmell>,
+private fun WineFlavorPicker(
+    wineSmellKeywords: List<WineSmellKeyword>,
+    isWineSmellKeywordSelected: (WineSmellOption) -> Boolean,
     updateWineSmell: (WineSmellOption) -> Unit = {}, navigateToStandardSmell: () -> Unit
 ) {
     Column(
@@ -194,41 +197,46 @@ private fun WineFavorPicker(
         Column(
             verticalArrangement = Arrangement.spacedBy(25.dp)
         ) {
-            wineSmells.forEach {
-                WineSmellContainer(wineSmell = it, updateWineSmell = updateWineSmell)
+            wineSmellKeywords.forEach {
+                WineSmellContainer(
+                    wineSmellKeyword = it,
+                    isWineSmellKeywordSelected = isWineSmellKeywordSelected,
+                    updateWineSmell = updateWineSmell
+                )
             }
         }
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun WineSmellContainer(
-    wineSmell: WineSmell,
+    wineSmellKeyword: WineSmellKeyword,
+    isWineSmellKeywordSelected: (WineSmellOption) -> Boolean,
     updateWineSmell: (WineSmellOption) -> Unit = {}
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
         Text(
-            text = wineSmell.title,
+            text = wineSmellKeyword.title,
             modifier = Modifier.padding(start = 24.dp),
             style = WineyTheme.typography.bodyB2,
             color = WineyTheme.colors.gray_500
         )
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(5.dp)
+        FlowRow(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            Spacer(modifier = Modifier.width(14.dp))
-            wineSmell.options.forEach {
+            wineSmellKeyword.options.forEach {
                 NoteFeatureText(
                     name = it.name,
-                    enable = it.isSelected,
+                    enable = isWineSmellKeywordSelected(it),
                 ) {
                     updateWineSmell(it.copy(isSelected = !it.isSelected))
                 }
             }
-            Spacer(modifier = Modifier.width(14.dp))
         }
     }
 }

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoFlavorScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoFlavorScreen.kt
@@ -105,7 +105,7 @@ fun NoteWineInfoFlavorScreen(
             HeightSpacer(30.dp)
             WineTasteSlider(
                 score = uiState.wineNote.alcohol,
-                onValueChange = { viewModel.updateWineNoteAlcohol(it) },
+                onValueChange = { viewModel.updateAlcohol(it) },
                 title = "알코올",
                 subTitle = "알코올 세기의 정도"
             )

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoLevelScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoLevelScreen.kt
@@ -176,9 +176,9 @@ fun NoteWineInfoLevelScreen(
                 contentAlignment = Alignment.Center
             ) {
                 NumberPicker(
-                    value = uiState.wineNote.alcohol,
+                    value = uiState.wineNote.officialAlcohol.toInt(),
                     onValueChange = {
-                        viewModel.updateAlcohol(it)
+                        viewModel.updateOfficialAlcohol(it.toDouble())
                     },
                     range = 0..20,
                     textStyle = WineyTheme.typography.title1.copy(

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoLevelScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoLevelScreen.kt
@@ -175,16 +175,24 @@ fun NoteWineInfoLevelScreen(
                     .weight(1f),
                 contentAlignment = Alignment.Center
             ) {
-                NumberPicker(
-                    value = uiState.wineNote.officialAlcohol.toInt(),
-                    onValueChange = {
-                        viewModel.updateOfficialAlcohol(it.toDouble())
-                    },
-                    range = 0..20,
-                    textStyle = WineyTheme.typography.title1.copy(
-                        color = WineyTheme.colors.gray_50
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    NumberPicker(
+                        value = uiState.wineNote.officialAlcohol.toInt(),
+                        onValueChange = {
+                            viewModel.updateOfficialAlcohol(it.toDouble())
+                        },
+                        range = 0..20,
+                        textStyle = WineyTheme.typography.title1.copy(
+                            color = WineyTheme.colors.gray_50
+                        )
                     )
-                )
+                    Text(
+                        text = "°",
+                        style = WineyTheme.typography.title1.copy(
+                            color = WineyTheme.colors.gray_50
+                        )
+                    )
+                }
             }
             Row(
                 modifier = Modifier.padding(horizontal = 24.dp),

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteContract.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteContract.kt
@@ -1,8 +1,5 @@
 package com.teamwiney.notewrite
 
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
-import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavOptions
 import androidx.paging.LoadState
 import androidx.paging.LoadStates
@@ -10,6 +7,7 @@ import androidx.paging.PagingData
 import com.teamwiney.core.common.base.UiEffect
 import com.teamwiney.core.common.base.UiEvent
 import com.teamwiney.core.common.base.UiState
+import com.teamwiney.core.common.model.WineSmell
 import com.teamwiney.data.network.model.response.SearchWine
 import com.teamwiney.data.network.model.response.Wine
 import com.teamwiney.notewrite.model.WineNote
@@ -36,47 +34,25 @@ class NoteWriteContract {
         val selectedWineInfo: Wine = Wine.default(),
         val wineNote: WineNote = WineNote.default(),
         val hintPopupOpen: Boolean = false,
-        val wineSmells: List<WineSmell> = listOf(
-            WineSmell(
+        val wineSmellKeywords: List<WineSmellKeyword> = listOf(
+            WineSmellKeyword(
                 title = "과일향",
-                options = listOf(
-                    WineSmellOption("과일향"),
-                    WineSmellOption("베리류"),
-                    WineSmellOption("레몬/라임"),
-                    WineSmellOption("사과/배"),
-                    WineSmellOption("복숭아/자두")
-                )
+                options = WineSmell.values().filter { it.type == "FRUIT" }.map { WineSmellOption(it.korName, it.value) }
             ),
-            WineSmell(
+            WineSmellKeyword(
                 title = "내추럴",
-                options = listOf(
-                    WineSmellOption("꽃향"),
-                    WineSmellOption("풀/나무"),
-                    WineSmellOption("허브향")
-                )
+                options = WineSmell.values().filter { it.type == "NATURAL" }.map { WineSmellOption(it.korName, it.value) }
             ),
-            WineSmell(
+            WineSmellKeyword(
                 title = "오크향",
-                options = listOf(
-                    WineSmellOption("오크향"),
-                    WineSmellOption("향신로"),
-                    WineSmellOption("견과류"),
-                    WineSmellOption("바닐라"),
-                    WineSmellOption("초콜릿")
-                )
+                options = WineSmell.values().filter { it.type == "OAK" }.map { WineSmellOption(it.korName, it.value) }
             ),
-            WineSmell(
+            WineSmellKeyword(
                 title = "기타",
-                options = listOf(
-                    WineSmellOption("부싯돌"),
-                    WineSmellOption("빵"),
-                    WineSmellOption("고무"),
-                    WineSmellOption("흙/재"),
-                    WineSmellOption("약품")
-                )
-            ),
+                options = WineSmell.values().filter { it.type == "OTHER" }.map { WineSmellOption(it.korName, it.value) }
+            )
         ),
-        val thumbX: Float = 0f,
+        val thumbX: Float = 0f
     ) : UiState
 
     sealed class Event : UiEvent {

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteSelectWineScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteSelectWineScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -49,14 +48,13 @@ fun NoteWriteSelectWineScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val effectFlow = viewModel.effect
 
-    // Device Width
-    val deviceWidth = LocalContext.current.resources.displayMetrics.widthPixels
-
     val selectedWine = uiState.selectedWine
 
     BackHandler {
         if (bottomSheetState.bottomSheetState.isVisible) {
             bottomSheetState.hideBottomSheet()
+        } else {
+            appState.navController.navigateUp()
         }
     }
 

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteViewModel.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteViewModel.kt
@@ -30,6 +30,7 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
 import org.json.JSONObject
 import javax.inject.Inject
 
@@ -93,20 +94,24 @@ class NoteWriteViewModel @Inject constructor(
             put("tannin", wineNote.tannin)
             put("finish", wineNote.finish)
             put("memo", wineNote.memo)
+            put("rating", wineNote.rating)
 
             if (wineNote.vintage.isNotEmpty()) {
-                put("vintage", wineNote.vintage)
+                put("vintage", wineNote.vintage.toInt())
             }
 
             if (wineNote.price.isNotEmpty()) {
-                put("price", wineNote.price)
+                put("price", wineNote.price.toInt())
             }
 
             wineNote.buyAgain?.let {
                 put("buyAgain", it)
             }
 
-            put("smellKeywordsList", wineNote.smellKeywordList)
+            val smellKeywordsArray = JSONArray().apply {
+                wineNote.smellKeywordList.forEach { put(it) }
+            }
+            put("smellKeywordList", smellKeywordsArray)
         }
 
         val request = jsonObjectBuilder.toString().toRequestBody("application/json".toMediaType())
@@ -141,7 +146,7 @@ class NoteWriteViewModel @Inject constructor(
             val originalFile = fileFromContentUri(context, it)
             val compressedFile = resizeAndSaveImage(context, originalFile)
             val requestBody: RequestBody = compressedFile.asRequestBody("image/*".toMediaType())
-            MultipartBody.Part.createFormData("multipartFile", compressedFile.name, requestBody)
+            MultipartBody.Part.createFormData("multipartFiles", compressedFile.name, requestBody)
         }
     }
 

--- a/feature/note/src/main/java/com/teamwiney/notewrite/model/WineNote.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/model/WineNote.kt
@@ -26,7 +26,7 @@ data class WineNote(
             return WineNote(
                 wineId = 0,
                 vintage = "",
-                officialAlcohol = 0.0,
+                officialAlcohol = 12.0,
                 price = "",
                 color = Color.Red,
                 sweetness = 0,


### PR DESCRIPTION
## 변경사항

### 1. 이미지를 제외한 정보를 application/json 형태로 전송
이미지를 제외한 정보를 request객체에 담아 application/json 형태로 전송하도록 수정했습니다.

###  2. officialAlcohol과 alcohol 구분
기존에 넘버피커를 통해 설정하는 알코올 도수와 와인 정보 입력 시 입력하는 알코올의 정보가 동일시되는 문제를 수정했습니다.

###  3. 선택한 향 키워드가 전송되지 않는 문제 수정
 향 키워드를 선택하더라도 wineNote 객체에 반영되지 않는 문제를 해결했습니다.
 
###  4.  선택할 수 있는 향 키워드를 서버의 enum 값과 동일하게 수정
하드코딩된 향 키워드 대신 서버의 enum class와 동일하게 수정해서 사용했습니다.

###  5. rating 정보 누락 해결
 기존에 rating 정보가 누락되어 보내지지 않던 문제를 수정했습니다.
 
###  6. 이미지 파일 확장자도 같이 붙여 전송
 이미지 압축 후 새로 생성하는 파일에 확장자가 붙어있지 않던 문제를 해결했습니다.
 
###  7. ViewModel context leak를 막기 위해 멀티파트 변환 로직 Data Layer 에 위임
 뷰모델에 context를 주입할 경우 context leak 문제가 발생하기 때문에 멀티파트 변환 로직을 Data Layer의 repository 클래스에 위임했습니다.