### PR TITLE
[BUG] 노트 조회 / 상세보기 수정

### DIFF
--- a/core/common/src/main/java/com/teamwiney/core/common/WineyBottomSheetState.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/WineyBottomSheetState.kt
@@ -72,6 +72,7 @@ class WineyBottomSheetState(
     @OptIn(ExperimentalMaterialApi::class)
     fun showBottomSheet(content: SheetContent) = scope.launch {
         keyboardController?.hide()
+        bottomSheetState.hide()
         setBottomSheet(content)
         bottomSheetState.show()
     }

--- a/core/common/src/main/java/com/teamwiney/core/common/model/WineSmell.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/model/WineSmell.kt
@@ -18,6 +18,6 @@ enum class WineSmell(val type: String, val value: String, val korName: String) {
     FLINT("OTHER", "FLINT", "부싯돌"),
     BREAD("OTHER", "BREAD", "빵"),
     RUBBER("OTHER", "RUBBER", "고무"),
-    EARTHASH("OTHER", "EARTASH", "흙/재"),
+    EARTASH("OTHER", "EARTHASH", "흙/재"),
     MEDICINE("OTHER", "MEDICNE", "약품")
 }

--- a/data/src/main/java/com/teamwiney/data/network/model/response/TastingNoteDetail.kt
+++ b/data/src/main/java/com/teamwiney/data/network/model/response/TastingNoteDetail.kt
@@ -26,7 +26,7 @@ data class TastingNoteDetail(
             wineType = "Loading",
             region = "Region",
             star = 4,
-            color = "RED",
+            color = "#FF0000",
             buyAgain = true,
             varietal = "varietal",
             officialAlcohol = 0,

--- a/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpAuthenticationScreen.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpAuthenticationScreen.kt
@@ -54,6 +54,8 @@ fun SignUpAuthenticationScreen(
     BackHandler {
         if (bottomSheetState.bottomSheetState.isVisible) {
             bottomSheetState.hideBottomSheet()
+        } else {
+            appState.navController.navigateUp()
         }
     }
 

--- a/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpContract.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpContract.kt
@@ -81,7 +81,6 @@ class SignUpContract {
         object BackToLogin : Event()
         object CancelTasteSelection : Event()
         object SetPreferences : Event()
-
         object VerifyCode : Event()
     }
 

--- a/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpFavoriteTasteScreen.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpFavoriteTasteScreen.kt
@@ -52,6 +52,8 @@ fun SignUpFavoriteTasteScreen(
     BackHandler {
         if (bottomSheetState.bottomSheetState.isVisible) {
             bottomSheetState.hideBottomSheet()
+        } else {
+            appState.navController.navigateUp()
         }
     }
 

--- a/feature/home/src/main/java/com/teamwiney/analysis/AnalysisScreen.kt
+++ b/feature/home/src/main/java/com/teamwiney/analysis/AnalysisScreen.kt
@@ -51,6 +51,8 @@ fun AnalysisScreen(
     BackHandler {
         if (bottomSheetState.bottomSheetState.isVisible) {
             bottomSheetState.hideBottomSheet()
+        } else {
+            appState.navController.navigateUp()
         }
     }
 

--- a/feature/note/src/main/java/com/teamwiney/NoteNavigation.kt
+++ b/feature/note/src/main/java/com/teamwiney/NoteNavigation.kt
@@ -63,6 +63,7 @@ fun NavGraphBuilder.noteGraph(
         ) {
             NoteDetailScreen(
                 noteId = it.arguments?.getInt("noteId") ?: 0,
+                refreshNote = noteViewModel::getTastingNotes,
                 appState = appState,
                 bottomSheetState = bottomSheetState,
             )
@@ -70,6 +71,7 @@ fun NavGraphBuilder.noteGraph(
 
         noteWriteGraph(
             appState = appState,
+            refreshNote = noteViewModel::getTastingNotes,
             bottomSheetState = bottomSheetState
         )
     }

--- a/feature/note/src/main/java/com/teamwiney/notecollection/NoteScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notecollection/NoteScreen.kt
@@ -83,6 +83,8 @@ fun NoteScreen(
     BackHandler {
         if (bottomSheetState.bottomSheetState.isVisible) {
             bottomSheetState.hideBottomSheet()
+        } else {
+            appState.navController.navigateUp()
         }
     }
 

--- a/feature/note/src/main/java/com/teamwiney/notecollection/NoteScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notecollection/NoteScreen.kt
@@ -96,6 +96,8 @@ fun NoteScreen(
     }
 
     LaunchedEffect(true) {
+        viewModel.getTastingNotes()
+
         effectFlow.collectLatest { effect ->
             when (effect) {
                 is NoteContract.Effect.NavigateTo -> {

--- a/feature/note/src/main/java/com/teamwiney/notecollection/NoteScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notecollection/NoteScreen.kt
@@ -296,7 +296,10 @@ fun NoteFilterSection(
                     item {
                         NoteSelectedFilterChip(
                             name = "재구매 의사",
-                            onClose = { viewModel.updateBuyAgainSelected(true) },
+                            onClose = {
+                                viewModel.updateBuyAgainSelected(true)
+                                viewModel.getTastingNotes()
+                            },
                             onClick = {
                                 viewModel.processEvent(NoteContract.Event.ShowFilter)
                             }

--- a/feature/note/src/main/java/com/teamwiney/notecollection/NoteViewModel.kt
+++ b/feature/note/src/main/java/com/teamwiney/notecollection/NoteViewModel.kt
@@ -75,6 +75,7 @@ class NoteViewModel @Inject constructor(
         ).onStart {
             updateState(currentState.copy(isLoading = true))
         }.collectLatest {
+            updateState(currentState.copy(isLoading = false))
             when (it) {
                 is ApiResult.Success -> {
                     updateState(

--- a/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailContract.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailContract.kt
@@ -3,6 +3,7 @@ package com.teamwiney.notedetail
 import androidx.navigation.NavOptions
 import com.teamwiney.core.common.base.UiEffect
 import com.teamwiney.core.common.base.UiEvent
+import com.teamwiney.core.common.base.UiSheet
 import com.teamwiney.core.common.base.UiState
 import com.teamwiney.data.network.model.response.TastingNoteDetail
 
@@ -13,6 +14,9 @@ class NoteDetailContract {
     ) : UiState
 
     sealed class Event : UiEvent {
+        object ShowNoteOptionBottomSheet : Event()
+
+        object ShowNoteDeleteBottomSheet : Event()
     }
 
     sealed class Effect : UiEffect {
@@ -22,7 +26,15 @@ class NoteDetailContract {
         ) : Effect()
 
         data class ShowSnackBar(val message: String) : Effect()
+
+        data class ShowBottomSheet(val bottomSheet: BottomSheet) : Effect()
+
         object NoteDeleted : Effect()
+    }
+
+    sealed class BottomSheet : UiSheet {
+        object NoteOption : BottomSheet()
+        object NoteDelete : BottomSheet()
     }
 
 }

--- a/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailScreen.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.teamwiney.core.common.WineyAppState
 import com.teamwiney.core.common.WineyBottomSheetState
 import com.teamwiney.core.design.R
+import com.teamwiney.notedetail.component.NoteDeleteBottomSheet
 import com.teamwiney.notedetail.component.NoteDetailBottomSheet
 import com.teamwiney.notedetail.component.WineInfo
 import com.teamwiney.notedetail.component.WineMemo
@@ -64,6 +65,34 @@ fun NoteDetailScreen(
                     appState.showSnackbar(effect.message)
                 }
 
+                is NoteDetailContract.Effect.ShowBottomSheet -> {
+                    bottomSheetState.showBottomSheet {
+                        when (effect.bottomSheet) {
+                            is NoteDetailContract.BottomSheet.NoteOption -> {
+                                NoteDetailBottomSheet(
+                                    deleteNote = {
+                                        bottomSheetState.hideBottomSheet()
+                                        viewModel.processEvent(
+                                            NoteDetailContract.Event.ShowNoteDeleteBottomSheet
+                                        )
+                                    },
+                                    patchNote = {
+                                    }
+                                )
+                            }
+
+                            is NoteDetailContract.BottomSheet.NoteDelete -> {
+                                NoteDeleteBottomSheet(
+                                    onConfirm = {
+                                        viewModel.deleteNote(uiState.noteDetail.noteId.toInt())
+                                    },
+                                    onCancel = bottomSheetState::hideBottomSheet
+                                )
+                            }
+                        }
+                    }
+                }
+
                 is NoteDetailContract.Effect.NoteDeleted -> {
                     appState.showSnackbar("노트가 삭제되었습니다.")
                     appState.navController.navigateUp()
@@ -93,17 +122,7 @@ fun NoteDetailScreen(
                         .clip(CircleShape)
                         .size(28.dp)
                         .clickable {
-                            bottomSheetState.showBottomSheet {
-                                NoteDetailBottomSheet(
-                                    showBottomSheet = bottomSheetState::showBottomSheet,
-                                    hideBottomSheet = bottomSheetState::hideBottomSheet,
-                                    deleteNote = {
-                                        viewModel.deleteNote(uiState.noteDetail.noteId.toInt())
-                                    },
-                                    patchNote = {
-                                    }
-                                )
-                            }
+                            viewModel.processEvent(NoteDetailContract.Event.ShowNoteOptionBottomSheet)
                         }
                 )
             }

--- a/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailScreen.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.collectLatest
 fun NoteDetailScreen(
     appState: WineyAppState,
     noteId: Int = 0,
+    refreshNote: () -> Unit,
     viewModel: NoteDetailViewModel = hiltViewModel(),
     bottomSheetState: WineyBottomSheetState
 ) {
@@ -66,6 +67,7 @@ fun NoteDetailScreen(
                 is NoteDetailContract.Effect.NoteDeleted -> {
                     appState.showSnackbar("노트가 삭제되었습니다.")
                     appState.navController.navigateUp()
+                    refreshNote()
                 }
             }
         }

--- a/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailViewModel.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailViewModel.kt
@@ -18,7 +18,20 @@ class NoteDetailViewModel @Inject constructor(
     override fun reduceState(event: NoteDetailContract.Event) {
         viewModelScope.launch {
             when (event) {
-                else -> {}
+                is NoteDetailContract.Event.ShowNoteOptionBottomSheet -> {
+                    postEffect(
+                        NoteDetailContract.Effect.ShowBottomSheet(
+                            NoteDetailContract.BottomSheet.NoteOption
+                        )
+                    )
+                }
+                is NoteDetailContract.Event.ShowNoteDeleteBottomSheet -> {
+                    postEffect(
+                        NoteDetailContract.Effect.ShowBottomSheet(
+                            NoteDetailContract.BottomSheet.NoteDelete
+                        )
+                    )
+                }
             }
         }
     }

--- a/feature/note/src/main/java/com/teamwiney/notedetail/component/NoteDetailBottomSheet.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/component/NoteDetailBottomSheet.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.teamwiney.core.common.`typealias`.SheetContent
 import com.teamwiney.ui.theme.WineyTheme
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 
@@ -55,7 +54,7 @@ fun NoteDetailBottomSheet(
                 .clickable {
                     localScope.launch {
                         hideBottomSheet()
-                        delay(100L)
+                        
                         showBottomSheet {
                             NoteDeleteBottomSheet(
                                 onConfirm = deleteNote,

--- a/feature/note/src/main/java/com/teamwiney/notedetail/component/NoteDetailBottomSheet.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/component/NoteDetailBottomSheet.kt
@@ -8,25 +8,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.teamwiney.core.common.`typealias`.SheetContent
 import com.teamwiney.ui.theme.WineyTheme
-import kotlinx.coroutines.launch
 
 
 @Composable
 fun NoteDetailBottomSheet(
-    showBottomSheet: (SheetContent) -> Unit,
-    hideBottomSheet: () -> Unit,
     deleteNote: () -> Unit,
     patchNote: () -> Unit
 ) {
-
-    val localScope = rememberCoroutineScope()
-
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -51,18 +43,7 @@ fun NoteDetailBottomSheet(
             style = WineyTheme.typography.bodyB1,
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable {
-                    localScope.launch {
-                        hideBottomSheet()
-                        
-                        showBottomSheet {
-                            NoteDeleteBottomSheet(
-                                onConfirm = deleteNote,
-                                onCancel = hideBottomSheet
-                            )
-                        }
-                    }
-                }
+                .clickable { deleteNote() }
                 .padding(20.dp)
         )
         Text(

--- a/feature/note/src/main/java/com/teamwiney/notedetail/component/WineSmellFeature.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/component/WineSmellFeature.kt
@@ -2,11 +2,9 @@ package com.teamwiney.notedetail.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -19,8 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.toColorInt
@@ -44,23 +41,19 @@ fun WineSmellFeature(noteDetail: TastingNoteDetail) {
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Row {
-                Box(
+                Spacer(
                     modifier = Modifier
+                        .background(
+                            brush = Brush.radialGradient(
+                                listOf(
+                                    Color(noteDetail.color.toColorInt()),
+                                    Color.Transparent
+                                )
+                            ),
+                            shape = CircleShape
+                        )
                         .size(41.dp)
-                        .blur(5.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Spacer(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(5.dp)
-                            .clip(CircleShape)
-                            .background(
-                                color = Color(noteDetail.color.toColorInt()),
-                                shape = CircleShape
-                            )
-                    )
-                }
+                )
 
                 Spacer(
                     modifier = Modifier

--- a/feature/note/src/main/java/com/teamwiney/notedetail/component/WineSmellFeature.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/component/WineSmellFeature.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.toColorInt
 import com.teamwiney.data.network.model.response.TastingNoteDetail
 import com.teamwiney.ui.theme.WineyTheme
 
@@ -55,7 +56,7 @@ fun WineSmellFeature(noteDetail: TastingNoteDetail) {
                             .padding(5.dp)
                             .clip(CircleShape)
                             .background(
-                                color = Color(0xFFEC7CA4).copy(0.5f),
+                                color = Color(noteDetail.color.toColorInt()),
                                 shape = CircleShape
                             )
                     )

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoMemoScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoMemoScreen.kt
@@ -59,9 +59,11 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.startActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.navOptions
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.teamwiney.core.common.WineyAppState
+import com.teamwiney.core.common.navigation.NoteDestinations
 import com.teamwiney.core.common.rememberWineyAppState
 import com.teamwiney.core.design.R
 import com.teamwiney.notedetail.component.NoteFeatureText
@@ -76,6 +78,7 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun NoteWineInfoMemoScreen(
     appState: WineyAppState = rememberWineyAppState(),
+    refreshNote: () -> Unit,
     viewModel: NoteWriteViewModel = hiltViewModel(),
 ) {
 
@@ -134,6 +137,17 @@ fun NoteWineInfoMemoScreen(
 
                 is NoteWriteContract.Effect.ShowSnackBar -> {
                     appState.showSnackbar(effect.message)
+                }
+
+                is NoteWriteContract.Effect.NoteWriteSuccess -> {
+                    appState.navigate(
+                        destination = NoteDestinations.ROUTE,
+                        navOptions = navOptions {
+                            popUpTo(NoteDestinations.ROUTE) {
+                                inclusive = true
+                            }
+                        }
+                    )
                 }
             }
         }

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineSearchScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineSearchScreen.kt
@@ -85,6 +85,8 @@ fun NoteWineSearchScreen(
                 is NoteWriteContract.Effect.ShowSnackBar -> {
                     appState.showSnackbar(effect.message)
                 }
+
+                else -> { }
             }
         }
     }

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteContract.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteContract.kt
@@ -66,6 +66,8 @@ class NoteWriteContract {
         ) : Effect()
 
         data class ShowSnackBar(val message: String) : Effect()
+
+        object NoteWriteSuccess : Effect()
     }
 
 }

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteNavigation.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteNavigation.kt
@@ -11,6 +11,7 @@ import com.teamwiney.rememberNavControllerBackStackEntry
 
 fun NavGraphBuilder.noteWriteGraph(
     appState: WineyAppState,
+    refreshNote: () -> Unit,
     bottomSheetState: WineyBottomSheetState
 ) {
     navigation(
@@ -126,6 +127,7 @@ fun NavGraphBuilder.noteWriteGraph(
             )
             NoteWineInfoMemoScreen(
                 appState = appState,
+                refreshNote = refreshNote,
                 viewModel = hiltViewModel(backStackEntry),
             )
         }

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteSelectWineScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteSelectWineScreen.kt
@@ -68,6 +68,8 @@ fun NoteWriteSelectWineScreen(
                 is NoteWriteContract.Effect.ShowSnackBar -> {
                     appState.showSnackbar(effect.message)
                 }
+
+                else -> { }
             }
         }
     }

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteViewModel.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteViewModel.kt
@@ -9,7 +9,6 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import com.teamwiney.core.common.base.BaseViewModel
-import com.teamwiney.core.common.navigation.NoteDestinations
 import com.teamwiney.data.network.adapter.ApiResult
 import com.teamwiney.data.network.model.response.SearchWine
 import com.teamwiney.data.pagingsource.SearchWinesPagingSource
@@ -95,7 +94,7 @@ class NoteWriteViewModel @Inject constructor(
             Log.i("NoteWriteViewModel", "writeTastingNote: $it")
             when (it) {
                 is ApiResult.Success -> {
-                    postEffect(NoteWriteContract.Effect.NavigateTo(NoteDestinations.ROUTE))
+                    postEffect(NoteWriteContract.Effect.NoteWriteSuccess)
                 }
 
                 is ApiResult.ApiError -> {


### PR DESCRIPTION
## 변경사항

### 1. 노트 삭제 바텀 시트가 잘려보이는 문제 수정
삭제하기 / 수정하기 옵션이 있는 바텀 시트에서 삭제 버튼을 누를 시 바텀시트가 잘리는 문제를 수정했습니다.

###  2. 바텀 시트가 닫혀있는 상태로 뒤로 가기 누를 시 이전 화면 이동
BackHandler를 잘못 설정해서 뒤로 가기를 눌러도 이전 화면으로 이동하지 못하는 문제를 수정했습니다.

###  3. 노트 상세보기 와인 색상 표시
서버에서 받아온 Color Hex String 값을 Compose Color로 변환 후 표기합니다.
 
###  4. 노트 삭제, 작성 시 노트 목록 페이지 새로고침
노트 목록에 변동 사항이 생기기 때문에 새로고침하였습니다.

###  5. 노트 상세화면 색상을 blur가 아닌 radial Gradient로 변경
피그마상에서 radial Gradient로 표시하길래 수정했습니다. (=컬러피커와 동일한 방식)
 
###  6. SmellKeywords 오타 수정
EARTASH의 value값을 EARTASH -> EARTHASH 로 수정했습니다.
 
###  7. 노트 갯수가 0개일 시 스켈레톤 UI가 뜨는 현상 수정
노트 갯수를 나타나기 위해 viewModel에서 getTastingNotesCount() 호출 시 통신이 끝났음에도 isLoading = true로 유지하기 때문에 생긴 현상으로 수정했습니다.

### 8. 재구매 의사 필터 제거 시 노트 목록 새로고침
재구매 의사 필터 제거 시에도 노트 목록이 새로고침됩니다.