### PR TITLE
[FIX] onInit 메소드 제거

### DIFF
--- a/app/src/main/java/com/teamwiney/winey/WineyNavHost.kt
+++ b/app/src/main/java/com/teamwiney/winey/WineyNavHost.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavDestination
 import androidx.navigation.compose.NavHost
 import com.teamwiney.analysis.analysisGraph
@@ -27,12 +26,9 @@ import com.teamwiney.core.common.navigation.TopLevelDestination
 import com.teamwiney.core.common.rememberWineyAppState
 import com.teamwiney.core.common.rememberWineyBottomSheetState
 import com.teamwiney.createnote.mapGraph
-import com.teamwiney.home.HomeViewModel
 import com.teamwiney.home.homeGraph
-import com.teamwiney.mypage.MyPageViewModel
 import com.teamwiney.mypage.myPageGraph
 import com.teamwiney.noteGraph
-import com.teamwiney.notecollection.NoteViewModel
 import com.teamwiney.ui.components.BottomNavigationBar
 import com.teamwiney.ui.components.BottomNavigationItem
 import com.teamwiney.ui.theme.WineyTheme
@@ -43,20 +39,6 @@ fun WineyNavHost() {
     val appState = rememberWineyAppState()
     val bottomSheetState = rememberWineyBottomSheetState()
     val navController = appState.navController
-
-    // 메인화면 뷰 모델들
-    val homeViewModel: HomeViewModel = viewModel()
-    val noteViewModel: NoteViewModel = viewModel()
-    val myPageViewModel: MyPageViewModel = viewModel()
-
-    // 초기 메인 화면 진입 시 수행해야할 작업을 정의합니다.
-    val onInit: () -> Unit = {
-        homeViewModel.getRecommendWines()
-        homeViewModel.getWineTips()
-        noteViewModel.getTastingNotes()
-        myPageViewModel.getUserWineGrade()
-        myPageViewModel.getWineGradeStandard()
-    }
 
     ModalBottomSheetLayout(
         sheetContent = {
@@ -92,26 +74,22 @@ fun WineyNavHost() {
             ) {
                 authGraph(
                     appState = appState,
-                    bottomSheetState = bottomSheetState,
-                    onInit = onInit
+                    bottomSheetState = bottomSheetState
                 )
                 homeGraph(
-                    appState = appState,
-                    homeViewModel = homeViewModel,
+                    appState = appState
                 )
                 mapGraph(
                     appState = appState,
-                    bottomSheetState = bottomSheetState,
+                    bottomSheetState = bottomSheetState
                 )
                 noteGraph(
                     appState = appState,
-                    noteViewModel = noteViewModel,
-                    bottomSheetState = bottomSheetState,
+                    bottomSheetState = bottomSheetState
                 )
                 myPageGraph(
                     appState = appState,
-                    myPageViewModel = myPageViewModel,
-                    bottomSheetState = bottomSheetState,
+                    bottomSheetState = bottomSheetState
                 )
                 analysisGraph(
                     appState = appState,

--- a/feature/auth/src/main/java/com/teamwiney/auth/AuthNavigation.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/AuthNavigation.kt
@@ -13,7 +13,6 @@ import com.teamwiney.core.common.navigation.AuthDestinations
 fun NavGraphBuilder.authGraph(
     appState: WineyAppState,
     bottomSheetState: WineyBottomSheetState,
-    onInit: () -> Unit,
 ) {
     navigation(
         route = AuthDestinations.ROUTE,
@@ -21,20 +20,15 @@ fun NavGraphBuilder.authGraph(
     ) {
         composable(route = AuthDestinations.SPLASH) {
             SplashScreen(
-                appState = appState,
-                onInit = onInit,
+                appState = appState
             )
         }
 
-        loginGraph(
-            appState = appState,
-            onInit = onInit,
-        )
+        loginGraph(appState = appState)
 
         signUpGraph(
             appState = appState,
-            bottomSheetState = bottomSheetState,
-            onInit = onInit,
+            bottomSheetState = bottomSheetState
         )
     }
 }

--- a/feature/auth/src/main/java/com/teamwiney/auth/login/LoginNavigation.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/login/LoginNavigation.kt
@@ -8,8 +8,7 @@ import com.teamwiney.core.common.WineyAppState
 import com.teamwiney.core.common.navigation.AuthDestinations
 
 fun NavGraphBuilder.loginGraph(
-    appState: WineyAppState,
-    onInit: () -> Unit
+    appState: WineyAppState
 ) {
     navigation(
         route = AuthDestinations.Login.ROUTE,
@@ -20,8 +19,7 @@ fun NavGraphBuilder.loginGraph(
 
             LoginScreen(
                 appState = appState,
-                viewModel = viewModel,
-                onInit = onInit
+                viewModel = viewModel
             )
         }
     }

--- a/feature/auth/src/main/java/com/teamwiney/auth/login/LoginScreen.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/login/LoginScreen.kt
@@ -47,8 +47,7 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun LoginScreen(
     appState: WineyAppState,
-    viewModel: LoginViewModel,
-    onInit: () -> Unit
+    viewModel: LoginViewModel
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val effectFlow = viewModel.effect
@@ -74,9 +73,6 @@ fun LoginScreen(
         effectFlow.collectLatest { effect ->
             when (effect) {
                 is LoginContract.Effect.NavigateTo -> {
-                    if (effect.destination == HomeDestinations.ROUTE) {
-                        onInit()
-                    }
                     appState.navigate(effect.destination, effect.navOptions)
                 }
 
@@ -142,7 +138,6 @@ fun LoginScreen(
                 SocialLoginButton(drawable = R.mipmap.img_lock) {
                     appState.showSnackbar("홈 화면 테스트 입니다.")
                     viewModel.testLogin {
-                        onInit()
                         appState.navigate(HomeDestinations.ROUTE) {
                             popUpTo(AuthDestinations.Login.ROUTE) {
                                 inclusive = true

--- a/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpCompleteScreen.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpCompleteScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.teamwiney.core.common.WineyAppState
 import com.teamwiney.core.common.navigation.AuthDestinations
 import com.teamwiney.core.common.navigation.HomeDestinations
@@ -21,12 +20,10 @@ import com.teamwiney.ui.theme.WineyTheme
 
 @Composable
 fun SignUpCompleteScreen(
-    appState: WineyAppState,
-    onInit: () -> Unit
+    appState: WineyAppState
 ) {
 
     val onSignUpComplete = {
-        onInit()
         appState.navigate(HomeDestinations.ROUTE) {
             popUpTo(AuthDestinations.SignUp.ROUTE) {
                 inclusive = true

--- a/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpNavigation.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpNavigation.kt
@@ -17,7 +17,6 @@ import com.teamwiney.core.common.navigation.AuthDestinations
 fun NavGraphBuilder.signUpGraph(
     appState: WineyAppState,
     bottomSheetState: WineyBottomSheetState,
-    onInit: () -> Unit,
 ) {
     navigation(
         route = "${AuthDestinations.SignUp.ROUTE}?userId={userId}",
@@ -73,10 +72,7 @@ fun NavGraphBuilder.signUpGraph(
         }
 
         composable(route = AuthDestinations.SignUp.COMPLETE) {
-            SignUpCompleteScreen(
-                appState = appState,
-                onInit = onInit
-            )
+            SignUpCompleteScreen(appState = appState)
         }
     }
 }

--- a/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashScreen.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashScreen.kt
@@ -15,15 +15,13 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.teamwiney.auth.login.component.SplashBackground
 import com.teamwiney.core.common.WineyAppState
-import com.teamwiney.core.common.navigation.HomeDestinations
 import com.teamwiney.core.design.R
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun SplashScreen(
-    appState: WineyAppState,
-    onInit: () -> Unit,
+    appState: WineyAppState
 ) {
     val viewModel: SplashViewModel = hiltViewModel()
     val effectFlow = viewModel.effect
@@ -41,9 +39,6 @@ fun SplashScreen(
                 }
 
                 is SplashContract.Effect.NavigateTo -> {
-                    if (effect.destination == HomeDestinations.ROUTE) {
-                        onInit()
-                    }
                     appState.navigate(effect.destination, builder = effect.builder)
                 }
             }

--- a/feature/home/src/main/java/com/teamwiney/home/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/teamwiney/home/HomeNavigation.kt
@@ -1,5 +1,10 @@
 package com.teamwiney.home
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
@@ -10,25 +15,33 @@ import com.teamwiney.core.common.navigation.HomeDestinations
 
 
 fun NavGraphBuilder.homeGraph(
-    appState: WineyAppState,
-    homeViewModel: HomeViewModel,
+    appState: WineyAppState
 ) {
-
     navigation(
         route = HomeDestinations.ROUTE,
         startDestination = HomeDestinations.HOME
     ) {
         composable(route = HomeDestinations.HOME) {
+            val backStackEntry = rememberNavControllerBackStackEntry(
+                entry = it,
+                navController = appState.navController,
+                graph = HomeDestinations.ROUTE
+            )
             HomeScreen(
                 appState = appState,
-                viewModel = homeViewModel
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
 
         composable(route = HomeDestinations.WINE_TIP) {
+            val backStackEntry = rememberNavControllerBackStackEntry(
+                entry = it,
+                navController = appState.navController,
+                graph = HomeDestinations.ROUTE
+            )
             WineTipScreen(
                 appState = appState,
-                viewModel = homeViewModel
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
 
@@ -56,11 +69,25 @@ fun NavGraphBuilder.homeGraph(
                 }
             )
         ) { entry ->
+            val backStackEntry = rememberNavControllerBackStackEntry(
+                entry = entry,
+                navController = appState.navController,
+                graph = HomeDestinations.ROUTE
+            )
             WineDetailScreen(
                 appState = appState,
                 wineId = entry.arguments?.getLong("wineId") ?: 0L,
-                viewModel = homeViewModel
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
     }
+}
+
+@Composable
+fun rememberNavControllerBackStackEntry(
+    entry: NavBackStackEntry,
+    navController: NavController,
+    graph: String,
+) = remember(entry) {
+    navController.getBackStackEntry(graph)
 }

--- a/feature/home/src/main/java/com/teamwiney/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teamwiney/home/HomeScreen.kt
@@ -81,6 +81,9 @@ fun HomeScreen(
     }
 
     LaunchedEffect(true) {
+        viewModel.getRecommendWines()
+        viewModel.getWineTips()
+
         effectFlow.collectLatest { effect ->
             when (effect) {
                 is HomeContract.Effect.NavigateTo -> {

--- a/feature/mypage/src/main/java/com/teamwiney/mypage/MyPageNavigation.kt
+++ b/feature/mypage/src/main/java/com/teamwiney/mypage/MyPageNavigation.kt
@@ -2,6 +2,7 @@ package com.teamwiney.mypage
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -13,7 +14,6 @@ import com.teamwiney.core.common.navigation.MyPageDestinations
 
 fun NavGraphBuilder.myPageGraph(
     appState: WineyAppState,
-    myPageViewModel: MyPageViewModel,
     bottomSheetState: WineyBottomSheetState
 ) {
     navigation(
@@ -21,9 +21,14 @@ fun NavGraphBuilder.myPageGraph(
         startDestination = MyPageDestinations.MY_PAGE
     ) {
         composable(route = MyPageDestinations.MY_PAGE) {
+            val backStackEntry = rememberNavControllerBackStackEntry(
+                entry = it,
+                navController = appState.navController,
+                graph = MyPageDestinations.ROUTE
+            )
             MyPageScreen(
                 appState = appState,
-                viewModel = myPageViewModel
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
 
@@ -34,25 +39,40 @@ fun NavGraphBuilder.myPageGraph(
         }
 
         composable(route = MyPageDestinations.ACCOUNT) {
+            val backStackEntry = rememberNavControllerBackStackEntry(
+                entry = it,
+                navController = appState.navController,
+                graph = MyPageDestinations.ROUTE
+            )
             MyPageAccountScreen(
                 appState = appState,
-                viewModel = myPageViewModel,
+                viewModel = hiltViewModel(backStackEntry),
                 bottomSheetState = bottomSheetState
             )
         }
 
         composable(route = MyPageDestinations.WITHDRAWAL_REASON_SELECT) {
+            val backStackEntry = rememberNavControllerBackStackEntry(
+                entry = it,
+                navController = appState.navController,
+                graph = MyPageDestinations.ROUTE
+            )
             MyPageWithdrawalReasonSelectScreen(
                 appState = appState,
-                viewModel = myPageViewModel,
+                viewModel = hiltViewModel(backStackEntry),
                 bottomSheetState = bottomSheetState
             )
         }
 
         composable(route = MyPageDestinations.WITHDRAWAL_CONFIRM) {
+            val backStackEntry = rememberNavControllerBackStackEntry(
+                entry = it,
+                navController = appState.navController,
+                graph = MyPageDestinations.ROUTE
+            )
             MyPageWithdrawalConfirmScreen(
                 appState = appState,
-                viewModel = myPageViewModel,
+                viewModel = hiltViewModel(backStackEntry),
                 bottomSheetState = bottomSheetState
             )
         }

--- a/feature/mypage/src/main/java/com/teamwiney/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/teamwiney/mypage/MyPageScreen.kt
@@ -58,6 +58,9 @@ fun MyPageScreen(
     val context = LocalContext.current
 
     LaunchedEffect(true) {
+        viewModel.getUserWineGrade()
+        viewModel.getWineGradeStandard()
+
         effectFlow.collectLatest { effect ->
             when (effect) {
                 is MyPageContract.Effect.NavigateTo -> {

--- a/feature/note/src/main/java/com/teamwiney/NoteNavigation.kt
+++ b/feature/note/src/main/java/com/teamwiney/NoteNavigation.kt
@@ -2,6 +2,7 @@ package com.teamwiney
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -14,13 +15,11 @@ import com.teamwiney.core.common.WineyBottomSheetState
 import com.teamwiney.core.common.navigation.NoteDestinations
 import com.teamwiney.notecollection.NoteFilterScreen
 import com.teamwiney.notecollection.NoteScreen
-import com.teamwiney.notecollection.NoteViewModel
 import com.teamwiney.notedetail.NoteDetailScreen
 import com.teamwiney.notewrite.noteWriteGraph
 
 fun NavGraphBuilder.noteGraph(
     appState: WineyAppState,
-    noteViewModel: NoteViewModel,
     bottomSheetState: WineyBottomSheetState
 ) {
     navigation(
@@ -36,7 +35,7 @@ fun NavGraphBuilder.noteGraph(
             NoteScreen(
                 appState = appState,
                 bottomSheetState = bottomSheetState,
-                viewModel = noteViewModel,
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
 
@@ -48,7 +47,7 @@ fun NavGraphBuilder.noteGraph(
             )
             NoteFilterScreen(
                 appState = appState,
-                viewModel = noteViewModel,
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
 
@@ -61,17 +60,21 @@ fun NavGraphBuilder.noteGraph(
                 }
             )
         ) {
+            val backStackEntry = rememberNavControllerBackStackEntry(
+                entry = it,
+                navController = appState.navController,
+                graph = NoteDestinations.ROUTE
+            )
             NoteDetailScreen(
                 noteId = it.arguments?.getInt("noteId") ?: 0,
-                refreshNote = noteViewModel::getTastingNotes,
                 appState = appState,
+                viewModel = hiltViewModel(backStackEntry),
                 bottomSheetState = bottomSheetState,
             )
         }
 
         noteWriteGraph(
             appState = appState,
-            refreshNote = noteViewModel::getTastingNotes,
             bottomSheetState = bottomSheetState
         )
     }

--- a/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailScreen.kt
@@ -45,7 +45,6 @@ import kotlinx.coroutines.flow.collectLatest
 fun NoteDetailScreen(
     appState: WineyAppState,
     noteId: Int = 0,
-    refreshNote: () -> Unit,
     viewModel: NoteDetailViewModel = hiltViewModel(),
     bottomSheetState: WineyBottomSheetState
 ) {
@@ -96,7 +95,6 @@ fun NoteDetailScreen(
                 is NoteDetailContract.Effect.NoteDeleted -> {
                     appState.showSnackbar("노트가 삭제되었습니다.")
                     appState.navController.navigateUp()
-                    refreshNote()
                 }
             }
         }

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoMemoScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoMemoScreen.kt
@@ -73,7 +73,6 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun NoteWineInfoMemoScreen(
     appState: WineyAppState = rememberWineyAppState(),
-    refreshNote: () -> Unit,
     viewModel: NoteWriteViewModel = hiltViewModel(),
 ) {
 

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteNavigation.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWriteNavigation.kt
@@ -11,7 +11,6 @@ import com.teamwiney.rememberNavControllerBackStackEntry
 
 fun NavGraphBuilder.noteWriteGraph(
     appState: WineyAppState,
-    refreshNote: () -> Unit,
     bottomSheetState: WineyBottomSheetState
 ) {
     navigation(
@@ -39,7 +38,7 @@ fun NavGraphBuilder.noteWriteGraph(
             NoteWriteSelectWineScreen(
                 appState = appState,
                 viewModel = hiltViewModel(backStackEntry),
-                bottomSheetState = bottomSheetState,
+                bottomSheetState = bottomSheetState
             )
         }
 
@@ -52,7 +51,7 @@ fun NavGraphBuilder.noteWriteGraph(
             NoteWineInfoLevelScreen(
                 appState = appState,
                 bottomSheetState = bottomSheetState,
-                viewModel = hiltViewModel(backStackEntry),
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
 
@@ -65,7 +64,7 @@ fun NavGraphBuilder.noteWriteGraph(
             NoteWineInfoVintageAndPriceScreen(
                 appState = appState,
                 bottomSheetState = bottomSheetState,
-                viewModel = hiltViewModel(backStackEntry),
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
 
@@ -89,7 +88,7 @@ fun NavGraphBuilder.noteWriteGraph(
             )
             NoteWineInfoFlavorScreen(
                 appState = appState,
-                viewModel = hiltViewModel(backStackEntry),
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
 
@@ -101,7 +100,7 @@ fun NavGraphBuilder.noteWriteGraph(
             )
             NoteWineInfoStandardSmellScreen(
                 appState = appState,
-                viewModel = hiltViewModel(backStackEntry),
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
 
@@ -114,7 +113,7 @@ fun NavGraphBuilder.noteWriteGraph(
             )
             NoteWineInfoStandardFlavorScreen(
                 appState = appState,
-                viewModel = hiltViewModel(backStackEntry),
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
 
@@ -127,11 +126,8 @@ fun NavGraphBuilder.noteWriteGraph(
             )
             NoteWineInfoMemoScreen(
                 appState = appState,
-                refreshNote = refreshNote,
-                viewModel = hiltViewModel(backStackEntry),
+                viewModel = hiltViewModel(backStackEntry)
             )
         }
-
-
     }
 }


### PR DESCRIPTION
## 변경사항

### 1. onInit 메소드 제거
앱 최초 실행 시 필요한 정보를 한 번만 호출하는 onInit 메소드를 제거했습니다.

### 2. 각 탭 클릭 시마다 필요한 정보 리프레쉬
홈 탭 클릭 시 추천 와인, 와인 Tip 갱신
노트 탭 클릭 시 작성 테이스팅 목록 갱신
마이페이지 클릭 시 등급 갱신이 이루어집니다.

## 이슈

기존에 onInit을 사용한 이유는 불필요한 API 호출을 줄이기 위함입니다.
후에 Paging3 RemoteMeditator를 통해 로컬 DB에 캐싱해서 API 호출 수를 줄일 수 있을 것 같습니다.