### PR TITLE
[BUG] 스플래시 / 로그인 로직 수정

### DIFF
--- a/core/common/src/main/java/com/teamwiney/core/common/model/UserStatus.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/model/UserStatus.kt
@@ -1,0 +1,5 @@
+package com.teamwiney.core.common.model
+
+enum class UserStatus {
+    ACTIVE, INACTIVE
+}

--- a/data/src/main/java/com/teamwiney/data/datasource/auth/AuthDataSource.kt
+++ b/data/src/main/java/com/teamwiney/data/datasource/auth/AuthDataSource.kt
@@ -16,6 +16,7 @@ import com.teamwiney.data.network.model.response.DeleteUser
 import com.teamwiney.data.network.model.response.GoogleAccessToken
 import com.teamwiney.data.network.model.response.SetPreferences
 import com.teamwiney.data.network.model.response.SocialLogin
+import com.teamwiney.data.network.model.response.UserInfo
 import com.teamwiney.data.network.model.response.VerifyAuthenticationMessage
 import kotlinx.coroutines.flow.Flow
 
@@ -46,6 +47,8 @@ interface AuthDataSource {
     ): Flow<ApiResult<ResponseWrapper<SetPreferences>>>
 
     fun refreshToken(refreshToken: String): Flow<ApiResult<ResponseWrapper<AccessToken>>>
+
+    fun getUserInfo(): Flow<ApiResult<ResponseWrapper<UserInfo>>>
 
     fun getConnections(): Flow<ApiResult<BaseResponse>>
 

--- a/data/src/main/java/com/teamwiney/data/datasource/auth/AuthDataSourceImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/datasource/auth/AuthDataSourceImpl.kt
@@ -62,6 +62,10 @@ class AuthDataSourceImpl @Inject constructor(
         emit(authService.refreshToken(refreshToken))
     }.flowOn(ioDispatcher)
 
+    override fun getUserInfo() = flow {
+        emit(authService.getUserInfo())
+    }.flowOn(ioDispatcher)
+
     override fun getConnections() = flow {
         emit(authService.getConnections())
     }.flowOn(ioDispatcher)

--- a/data/src/main/java/com/teamwiney/data/network/model/response/SocialLogin.kt
+++ b/data/src/main/java/com/teamwiney/data/network/model/response/SocialLogin.kt
@@ -1,5 +1,7 @@
 package com.teamwiney.data.network.model.response
 
+import com.teamwiney.core.common.model.UserStatus
+
 /**
  * - userStatus
 1. 취향설정 까지 모두 마쳐 회원 가입이 완료된 경우 → `ACTIVE`
@@ -21,12 +23,7 @@ data class SocialLogin(
     val accessToken: String,
     val userId: Int,
     val refreshToken: String,
-    val userStatus: String,
+    val userStatus: UserStatus,
     val messageStatus: String,
     val preferenceStatus: String
-) {
-    companion object {
-        const val USER_STATUS_ACTIVE = "ACTIVE"
-        const val USER_STATUS_INACTIVE = "INACTIVE"
-    }
-}
+)

--- a/data/src/main/java/com/teamwiney/data/network/model/response/UserInfo.kt
+++ b/data/src/main/java/com/teamwiney/data/network/model/response/UserInfo.kt
@@ -1,0 +1,9 @@
+package com.teamwiney.data.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import com.teamwiney.core.common.model.UserStatus
+
+data class UserInfo(
+    @SerializedName("userId") val userId: Int,
+    @SerializedName("status") val status: UserStatus
+)

--- a/data/src/main/java/com/teamwiney/data/network/service/AuthService.kt
+++ b/data/src/main/java/com/teamwiney/data/network/service/AuthService.kt
@@ -16,6 +16,7 @@ import com.teamwiney.data.network.model.response.DeleteUser
 import com.teamwiney.data.network.model.response.GoogleAccessToken
 import com.teamwiney.data.network.model.response.SetPreferences
 import com.teamwiney.data.network.model.response.SocialLogin
+import com.teamwiney.data.network.model.response.UserInfo
 import com.teamwiney.data.network.model.response.VerifyAuthenticationMessage
 import retrofit2.Response
 import retrofit2.http.Body
@@ -69,6 +70,9 @@ interface AuthService {
         @Body preferences: SetPreferencesRequest
     ): ApiResult<ResponseWrapper<SetPreferences>>
 
+    /** 유저 상태 정보 조회 API */
+    @GET("/info")
+    suspend fun getUserInfo(): ApiResult<ResponseWrapper<UserInfo>>
 
     /** 토큰 리프레쉬 API */
     @POST("/refresh")

--- a/data/src/main/java/com/teamwiney/data/repository/auth/AuthRepository.kt
+++ b/data/src/main/java/com/teamwiney/data/repository/auth/AuthRepository.kt
@@ -13,6 +13,7 @@ import com.teamwiney.data.network.model.response.DeleteUser
 import com.teamwiney.data.network.model.response.GoogleAccessToken
 import com.teamwiney.data.network.model.response.SetPreferences
 import com.teamwiney.data.network.model.response.SocialLogin
+import com.teamwiney.data.network.model.response.UserInfo
 import com.teamwiney.data.network.model.response.VerifyAuthenticationMessage
 import kotlinx.coroutines.flow.Flow
 
@@ -48,6 +49,8 @@ interface AuthRepository {
     fun refreshToken(
         refreshToken: String
     ): Flow<ApiResult<ResponseWrapper<AccessToken>>>
+
+    fun getUserInfo(): Flow<ApiResult<ResponseWrapper<UserInfo>>>
 
     fun getConnections(): Flow<ApiResult<BaseResponse>>
 

--- a/data/src/main/java/com/teamwiney/data/repository/auth/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/repository/auth/AuthRepositoryImpl.kt
@@ -59,6 +59,8 @@ class AuthRepositoryImpl @Inject constructor(
         request: PhoneNumberWithVerificationCodeRequest
     ) = authDataSource.verifyAuthCodeMessage(userId, request)
 
+    override fun getUserInfo() = authDataSource.getUserInfo()
+
     override fun getConnections() = authDataSource.getConnections()
 
     override fun registerFcmToken(

--- a/feature/auth/src/main/java/com/teamwiney/auth/login/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/login/LoginViewModel.kt
@@ -10,6 +10,7 @@ import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 import com.teamwiney.core.common.base.BaseViewModel
 import com.teamwiney.core.common.model.SocialType
+import com.teamwiney.core.common.model.UserStatus
 import com.teamwiney.core.common.navigation.AuthDestinations
 import com.teamwiney.core.common.navigation.HomeDestinations
 import com.teamwiney.core.common.util.Constants
@@ -17,7 +18,6 @@ import com.teamwiney.core.common.util.Constants.ACCESS_TOKEN
 import com.teamwiney.core.common.util.Constants.LOGIN_TYPE
 import com.teamwiney.core.common.util.Constants.REFRESH_TOKEN
 import com.teamwiney.data.network.adapter.ApiResult
-import com.teamwiney.data.network.model.response.SocialLogin
 import com.teamwiney.data.repository.auth.AuthRepository
 import com.teamwiney.data.repository.persistence.DataStoreRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -111,24 +111,17 @@ class LoginViewModel @Inject constructor(
                     updateState(currentState.copy(isLoading = false))
                     when (result) {
                         is ApiResult.Success -> {
+                            Log.i(
+                                "[ACCESS_TOKEN]",
+                                "accessToken: ${result.data.result.accessToken}"
+                            )
+                            Log.i(
+                                "[REFRESH_TOKEN]",
+                                "refreshToken: ${result.data.result.refreshToken}"
+                            )
+
                             val userStatus = result.data.result.userStatus
-                            if (userStatus == SocialLogin.USER_STATUS_ACTIVE) {
-                                Log.i(
-                                    "[ACCESS_TOKEN]",
-                                    "accessToken: ${result.data.result.accessToken}"
-                                )
-                                Log.i(
-                                    "[REFRESH_TOKEN]",
-                                    "refreshToken: ${result.data.result.refreshToken}"
-                                )
-                                dataStoreRepository.setStringValue(
-                                    ACCESS_TOKEN,
-                                    result.data.result.accessToken
-                                )
-                                dataStoreRepository.setStringValue(
-                                    REFRESH_TOKEN,
-                                    result.data.result.refreshToken
-                                )
+                            if (userStatus == UserStatus.ACTIVE) {
                                 dataStoreRepository.setStringValue(LOGIN_TYPE, socialType.name)
 
                                 postEffect(LoginContract.Effect.NavigateTo(
@@ -144,6 +137,8 @@ class LoginViewModel @Inject constructor(
                             }
 
                             runBlocking {
+                                dataStoreRepository.setStringValue(ACCESS_TOKEN, result.data.result.accessToken)
+                                dataStoreRepository.setStringValue(REFRESH_TOKEN, result.data.result.refreshToken)
                                 dataStoreRepository.setIntValue(Constants.USER_ID, result.data.result.userId)
                             }
                         }

--- a/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashContract.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashContract.kt
@@ -13,7 +13,7 @@ class SplashContract {
     ) : UiState
 
     sealed class Event : UiEvent {
-        object AutoLoginCheck : Event()
+        object CheckUserStatus : Event()
     }
 
     sealed class Effect : UiEffect {

--- a/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashScreen.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashScreen.kt
@@ -46,10 +46,8 @@ fun SplashScreen(
     LaunchedEffect(true) {
         viewModel.checkIsFirstLaunch()
 
-        viewModel.getConnections()
-        viewModel.registerFcmToken()
         delay(1500)
-        viewModel.processEvent(SplashContract.Event.AutoLoginCheck)
+        viewModel.processEvent(SplashContract.Event.CheckUserStatus)
 
         effectFlow.collectLatest { effect ->
             when (effect) {

--- a/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashViewModel.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashViewModel.kt
@@ -1,16 +1,13 @@
 package com.teamwiney.auth.splash
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.teamwiney.core.common.base.BaseViewModel
+import com.teamwiney.core.common.model.UserStatus
 import com.teamwiney.core.common.navigation.AuthDestinations
 import com.teamwiney.core.common.navigation.HomeDestinations
 import com.teamwiney.core.common.util.Constants
-import com.teamwiney.core.common.util.Constants.ACCESS_TOKEN
-import com.teamwiney.core.common.util.Constants.DEVICE_ID
-import com.teamwiney.core.common.util.Constants.FCM_TOKEN
 import com.teamwiney.core.common.util.Constants.IS_NOT_FIRST_LAUNCH
-import com.teamwiney.core.common.util.Constants.REFRESH_TOKEN
+import com.teamwiney.core.common.util.Constants.USER_ID
 import com.teamwiney.data.di.DispatcherModule
 import com.teamwiney.data.network.adapter.ApiResult
 import com.teamwiney.data.repository.auth.AuthRepository
@@ -20,7 +17,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 
@@ -42,8 +39,8 @@ class SplashViewModel @Inject constructor(
     override fun reduceState(event: SplashContract.Event) {
         viewModelScope.launch {
             when (event) {
-                SplashContract.Event.AutoLoginCheck -> {
-                    autoLoginCheck()
+                SplashContract.Event.CheckUserStatus -> {
+                    checkUserStatus()
                 }
             }
         }
@@ -58,55 +55,34 @@ class SplashViewModel @Inject constructor(
         }
     }
 
-    private fun autoLoginCheck() = viewModelScope.launch {
-        val refreshToken =
-            withContext(ioDispatcher) { dataStoreRepository.getStringValue(REFRESH_TOKEN).first() }
-        Log.i("[REFRESH_TOKEN] : ", refreshToken)
-        if (refreshToken.isNotEmpty()) {
-            refreshToken(refreshToken)
-        } else {
-            naviagateToLogin()
-        }
-    }
-
-    private fun refreshToken(refreshToken: String) = viewModelScope.launch {
-        authRepository.refreshToken(refreshToken).collectLatest { apiResult ->
-            when (apiResult) {
-                is ApiResult.Success -> {
-                    val accessToken = apiResult.data.result.accessToken
-                    withContext(ioDispatcher) {
-                        dataStoreRepository.setStringValue(ACCESS_TOKEN, accessToken)
-                    }
-                    navigateToMain()
-                }
-
-                else -> {
-                    naviagateToLogin()
-                }
-            }
-        }
-    }
-
-    fun registerFcmToken() = viewModelScope.launch {
-        val fcmToken = dataStoreRepository.getStringValue(FCM_TOKEN).first()
-        val deviceId = dataStoreRepository.getStringValue(DEVICE_ID).first()
-
-        authRepository.registerFcmToken(fcmToken, deviceId).collectLatest {
+    private fun checkUserStatus() = viewModelScope.launch {
+        authRepository.getUserInfo().collectLatest {
             when (it) {
+                is ApiResult.Success -> {
+                    val userInfo = it.data.result
+
+                    runBlocking { dataStoreRepository.setIntValue(USER_ID, userInfo.userId) }
+
+                    if (userInfo.status == UserStatus.ACTIVE) {
+                        getConnections()
+                        navigateToMain()
+                    } else {
+                        naviagateToLogin()
+                    }
+                }
+
                 is ApiResult.ApiError -> {
-                    postEffect(SplashContract.Effect.ShowSnackBar(it.message))
+                    naviagateToLogin()
                 }
 
                 is ApiResult.NetworkError -> {
                     postEffect(SplashContract.Effect.ShowSnackBar("네트워크 오류가 발생했습니다."))
                 }
-
-                else -> { }
             }
         }
     }
 
-    fun getConnections() = viewModelScope.launch {
+    private fun getConnections() = viewModelScope.launch {
         authRepository.getConnections().collectLatest {
             when (it) {
                 is ApiResult.ApiError -> {


### PR DESCRIPTION
## 변경사항
* 로그인 시 UserStatus 관계없이 토큰 저장
* 스플래시 화면에서 유저 상태 ACTIVE일 시 메인 화면 이동, INACTIVE일 시 로그인 화면 이동
* 로그인 (유저 상태 ACTIVE), 회원가입 시 FCM 토큰 등록

## 변경이유
따로 회원가입 API가 존재하지 않기 때문에 토큰 저장 시점이 클라이언트 입장에서는 명확하지 않습니다.
그렇다고 로그인 시점에서 저장을 하지 않는다면 취향 설정 (회원가입 과정) 후 메인 화면으로 넘어갈 시 토큰을 가지고 있지 않아 API 호출을 실패합니다.
따라서 토큰을 가지고 있되, 유저 상태가 INACTIVE인 상태에서 메인 화면으로 진입하는 것을 막아야 합니다.

이번에 새로 추가된 API를 통해 스플래시 화면에서 유저 상태가 ACTIVE라면 메인 화면, INACTIVE이거나 토큰 관련 에러 (401, 403) 가 발생하면 로그인 화면으로 보냄으로써 해결할 수 있습니다.

유저 뱃지 발급을 위한 `/connections` API, FCM 토큰 등록을 위한 `/fcm` API도 위 흐름에 밀접한 관계가 있습니다.
토큰을 가지고 있고, 유저 상태가 ACTIVE일 시 호출되어야 하기 때문입니다.

`/connections`는 스플래시 화면에서 유저 상태가 ACTIVE일 시 호출하면 됩니다.
`/fcm`은 기기 고유의 FCM 토큰을 등록하는 것이기 때문에 스플래시 화면에서 매번 등록하기 보다는 로그인 (유저 상태 ACTIVE일 시), 회원가입 완료 (user/{userId}/preferences 호출 성공) 시점에 호출하면 됩니다.
회원가입 시점에만 호출할 수도 있겠지만, 이미 있는 계정을 다른 기기에서 로그인할 시 다시 등록해야 하기 때문에 로그인 완료 시점에서도 호출합니다.