### PR TITLE
[BUG] 노트 QA

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         android:name=".WineyApp"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:windowSoftInputMode="adjustPan"
+        android:windowSoftInputMode="adjustResize"
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.Winey"
         tools:targetApi="31">
@@ -38,6 +38,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.Winey">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/core/design/src/main/java/com/teamwiney/ui/components/TasteScoreHorizontalBar.kt
+++ b/core/design/src/main/java/com/teamwiney/ui/components/TasteScoreHorizontalBar.kt
@@ -111,10 +111,11 @@ fun ScoreHorizontalBar(
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
 
         var barWidth by remember { mutableStateOf(0.dp) }
+
         val density = LocalDensity.current
 
         Row(
-            modifier = Modifier.width(maxOf(barWidth + 8.dp, (12.5 * label.length).dp)),
+            modifier = Modifier.width(maxOf(barWidth + 8.dp, (15 * label.length).dp)),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(

--- a/core/design/src/main/java/com/teamwiney/ui/components/detail/NoteTitleAndDescription.kt
+++ b/core/design/src/main/java/com/teamwiney/ui/components/detail/NoteTitleAndDescription.kt
@@ -2,6 +2,7 @@ package com.teamwiney.ui.components.detail
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -10,6 +11,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.teamwiney.core.design.R
 import com.teamwiney.ui.components.HeightSpacer
@@ -17,11 +21,39 @@ import com.teamwiney.ui.theme.WineyTheme
 
 
 @Composable
-fun TitleAndDescription(
+fun NoteTitleAndDescription(
+    id: Long,
+    date: String,
     type: String,
     name: String,
 ) {
     HeightSpacer(height = 20.dp)
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = buildAnnotatedString {
+                append("No.")
+                withStyle(SpanStyle(color = WineyTheme.colors.main_3)) {
+                    append("$id")
+                }
+            },
+            style = WineyTheme.typography.bodyB1.copy(
+                color = WineyTheme.colors.gray_50
+            )
+        )
+
+        Text(
+            text = date,
+            style = WineyTheme.typography.bodyB1.copy(
+                color = WineyTheme.colors.gray_50
+            )
+        )
+    }
+
+    HeightSpacer(height = 30.dp)
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)

--- a/core/design/src/main/res/drawable/ic_star.xml
+++ b/core/design/src/main/res/drawable/ic_star.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="26dp"
+    android:height="25dp"
+    android:viewportWidth="26"
+    android:viewportHeight="25">
+  <path
+      android:pathData="M13,1.5C12.785,7.484 7.984,12.285 2,12.5C7.984,12.715 12.785,17.516 13,23.5C13.215,17.516 18.016,12.715 24,12.5C18.016,12.285 13.215,7.484 13,1.5Z"
+      android:strokeAlpha="0.6"
+      android:fillColor="#AC8FFE"
+      android:fillAlpha="0.6"/>
+</vector>

--- a/feature/home/src/main/java/com/teamwiney/home/WineDetailScreen.kt
+++ b/feature/home/src/main/java/com/teamwiney/home/WineDetailScreen.kt
@@ -43,8 +43,8 @@ import com.teamwiney.ui.components.TasteScoreHorizontalBar
 import com.teamwiney.ui.components.TopBar
 import com.teamwiney.ui.components.WineBadge
 import com.teamwiney.ui.components.detail.DetailPageIndicator
-import com.teamwiney.ui.components.detail.TitleAndDescription
 import com.teamwiney.ui.components.detail.WineInfoBarGraph
+import com.teamwiney.ui.components.detail.WineTitleAndDescription
 import com.teamwiney.ui.theme.WineyTheme
 import kotlinx.coroutines.flow.collectLatest
 
@@ -92,7 +92,7 @@ fun WineDetailScreen(
                 .padding(horizontal = 20.dp)
                 .verticalScroll(rememberScrollState())
         ) {
-            TitleAndDescription(
+            WineTitleAndDescription(
                 type = uiState.wineDetail.type,
                 name = uiState.wineDetail.name
             )

--- a/feature/note/src/main/java/com/teamwiney/notecollection/NoteContract.kt
+++ b/feature/note/src/main/java/com/teamwiney/notecollection/NoteContract.kt
@@ -28,7 +28,7 @@ class NoteContract {
             )
         ),
         val tastingNotesCount: Long = 0,
-        val sortItems: List<String> = listOf("최신순", "인기순"),
+        val sortItems: List<String> = listOf("최신순", "평점순"),
         val selectedSort: Int = 0,
         val buyAgainSelected: Boolean = false,
         val typeFilter: List<WineTypeResponse> = emptyList(),

--- a/feature/note/src/main/java/com/teamwiney/notecollection/NoteScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notecollection/NoteScreen.kt
@@ -180,7 +180,6 @@ fun NoteScreen(
             }
         }
 
-
         FloatingActionButton(
             modifier = Modifier
                 .align(Alignment.BottomEnd)

--- a/feature/note/src/main/java/com/teamwiney/notecollection/NoteViewModel.kt
+++ b/feature/note/src/main/java/com/teamwiney/notecollection/NoteViewModel.kt
@@ -187,7 +187,8 @@ class NoteViewModel @Inject constructor(
         updateState(
             currentState.copy(
                 selectedTypeFilter = emptyList(),
-                selectedCountryFilter = emptyList()
+                selectedCountryFilter = emptyList(),
+                buyAgainSelected = false
             )
         )
         getTastingNotes()

--- a/feature/note/src/main/java/com/teamwiney/notecollection/components/NoteSortBottomSheet.kt
+++ b/feature/note/src/main/java/com/teamwiney/notecollection/components/NoteSortBottomSheet.kt
@@ -14,6 +14,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -29,6 +33,8 @@ fun NoteSortBottomSheet(
     onSelectSort: (String) -> Unit,
     applyFilter: () -> Unit
 ) {
+    var selectedSortType by remember { mutableStateOf(selectedSort) }
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -58,6 +64,7 @@ fun NoteSortBottomSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable {
+                        selectedSortType = sort
                         onSelectSort(sort)
                         applyFilter()
                     },
@@ -76,7 +83,7 @@ fun NoteSortBottomSheet(
                     )
                 )
 
-                if (selectedSort == sort) {
+                if (selectedSortType == sort) {
                     Icon(
                         modifier = Modifier.padding(end = 24.dp),
                         painter = painterResource(id = com.teamwiney.core.design.R.drawable.ic_arrow_down),

--- a/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/NoteDetailScreen.kt
@@ -37,7 +37,7 @@ import com.teamwiney.notedetail.component.WineSmellFeature
 import com.teamwiney.ui.components.HeightSpacer
 import com.teamwiney.ui.components.HeightSpacerWithLine
 import com.teamwiney.ui.components.TopBar
-import com.teamwiney.ui.components.detail.TitleAndDescription
+import com.teamwiney.ui.components.detail.NoteTitleAndDescription
 import com.teamwiney.ui.theme.WineyTheme
 import kotlinx.coroutines.flow.collectLatest
 
@@ -134,7 +134,9 @@ fun NoteDetailScreen(
                 modifier = Modifier.padding(horizontal = 24.dp)
             ) {
 
-                TitleAndDescription(
+                NoteTitleAndDescription(
+                    id = uiState.noteDetail.noteId,
+                    date = uiState.noteDetail.noteDate,
                     type = uiState.noteDetail.wineType,
                     name = uiState.noteDetail.wineName
                 )
@@ -146,10 +148,15 @@ fun NoteDetailScreen(
 
                 WineOrigin(uiState.noteDetail)
 
+                HeightSpacerWithLine(
+                    modifier = Modifier.padding(vertical = 20.dp),
+                    color = WineyTheme.colors.gray_900
+                )
+
                 WineSmellFeature(uiState.noteDetail)
 
                 HeightSpacerWithLine(
-                    modifier = Modifier.padding(vertical = 20.dp),
+                    modifier = Modifier.padding(top = 38.dp, bottom = 30.dp),
                     color = WineyTheme.colors.gray_900
                 )
 

--- a/feature/note/src/main/java/com/teamwiney/notedetail/component/WineMemo.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/component/WineMemo.kt
@@ -33,7 +33,7 @@ import com.teamwiney.ui.theme.WineyTheme
 @Composable
 fun WineMemo(noteDetail: TastingNoteDetail) {
 
-    Column() {
+    Column {
         Text(
             text = "Feature",
             style = WineyTheme.typography.display2,
@@ -83,7 +83,7 @@ fun WineMemo(noteDetail: TastingNoteDetail) {
                 )
         ) {
             Text(
-                text = noteDetail.memo,
+                text = noteDetail.memo.ifEmpty { "입력한 내용이 없어요!" },
                 modifier = Modifier.padding(14.dp),
                 style = WineyTheme.typography.captionM1,
                 color = WineyTheme.colors.gray_50

--- a/feature/note/src/main/java/com/teamwiney/notedetail/component/WineOrigin.kt
+++ b/feature/note/src/main/java/com/teamwiney/notedetail/component/WineOrigin.kt
@@ -3,9 +3,16 @@ package com.teamwiney.notedetail.component
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.teamwiney.data.network.model.response.TastingNoteDetail
 import com.teamwiney.ui.components.WineBadge
@@ -20,7 +27,42 @@ fun WineOrigin(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(30.dp)
     ) {
-        WineBadge(color = wine.wineType)
+        Column(
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            WineBadge(color = wine.wineType)
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    modifier = Modifier.size(22.dp),
+                    painter = painterResource(id = com.teamwiney.core.design.R.drawable.ic_star),
+                    contentDescription = "IC_STAR",
+                    tint = Color.Unspecified
+                )
+
+                Spacer(modifier = Modifier.width(3.dp))
+
+                Text(
+                    text = "${wine.star}.0",
+                    style = WineyTheme.typography.title2.copy(
+                        color = WineyTheme.colors.main_3
+                    )
+                )
+
+                if (wine.buyAgain) {
+                    Text(
+                        text = "・재구매",
+                        style = WineyTheme.typography.captionB1.copy(
+                            color = WineyTheme.colors.gray_50
+                        )
+                    )
+                }
+            }
+        }
+
 
         Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -59,7 +101,7 @@ fun WineOrigin(
                 )
 
                 Text(
-                    text = "${wine.officialAlcohol.toInt()}%",
+                    text = "${wine.officialAlcohol}%",
                     style = WineyTheme.typography.captionB1,
                     color = WineyTheme.colors.gray_50
                 )
@@ -87,7 +129,7 @@ fun WineOrigin(
                 )
 
                 Text(
-                    text = "${wine.noteDate}",
+                    text = "입력한 정보가 없어요",
                     style = WineyTheme.typography.captionB1,
                     color = WineyTheme.colors.gray_50
                 )

--- a/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoVintageAndPriceScreen.kt
+++ b/feature/note/src/main/java/com/teamwiney/notewrite/NoteWineInfoVintageAndPriceScreen.kt
@@ -124,9 +124,7 @@ fun NoteWineInfoVintageAndPriceScreen(
             }
         }
         Column(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth(),
+            modifier = Modifier.weight(1f).fillMaxWidth(),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -202,7 +200,7 @@ fun NoteWineInfoVintageAndPriceScreen(
         }
 
         Row(
-            modifier = Modifier.padding(horizontal = 24.dp),
+            modifier = Modifier.padding(start = 24.dp, end = 24.dp, bottom = 40.dp),
             horizontalArrangement = Arrangement.spacedBy(15.dp)
         ) {
             Box(
@@ -236,9 +234,7 @@ fun NoteWineInfoVintageAndPriceScreen(
 
             WButton(
                 text = "다음",
-                modifier = Modifier
-                    .weight(3f)
-                    .padding(bottom = 40.dp),
+                modifier = Modifier.weight(3f),
                 enableBackgroundColor = WineyTheme.colors.main_2,
                 disableBackgroundColor = WineyTheme.colors.gray_900,
                 disableTextColor = WineyTheme.colors.gray_600,


### PR DESCRIPTION
## 변경사항
* 필터 초기화 시 buyAgain을 null 처리해서 전체보기로 수정
* 카메라로 찍은 사진이 회전되서 업로드되는 문제 해결
* 노트 목록 조회 시 선택한 정렬 옵션에 따라 체크 표시가 이동하도록 수정
* 노트 상세보기 시 한줄평이 비어있으면 "입력한 내용이 없어요!" 텍스트 노출
* 노트 작성 시 키보드가 올라오면 건너뛰기 버튼이 가려지는 현상 해결
* 노트 상세보기 화면에서 맛 텍스가 줄바꿈이 되는 현상 해결
* 노트 상세보기 화면 재구매 의사, 번호 표시 및 디자인 수정 (서버 API 수정 후 빈티지 값 추가 예정)