### PR TITLE
[BUG] 앱 최초 실행 시 크래시

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,7 +110,7 @@ dependencies {
     implementation(libs.lifecycle.runtime.ktx)
     implementation(libs.lifecycle.runtime.compose)
     implementation(libs.coroutines.android)
-    implementation(libs.kotlin.bom)
+    implementation(platform(libs.kotlin.bom))
 
     implementation(libs.kakao.sdk.user)
     implementation(libs.play.services.auth)

--- a/app/src/main/java/com/teamwiney/winey/WineyApp.kt
+++ b/app/src/main/java/com/teamwiney/winey/WineyApp.kt
@@ -1,68 +1,15 @@
 package com.teamwiney.winey
 
 import android.app.Application
-import android.util.Log
-import com.google.firebase.installations.FirebaseInstallations
-import com.google.firebase.messaging.FirebaseMessaging
 import com.kakao.sdk.common.KakaoSdk
-import com.teamwiney.core.common.util.Constants.DEVICE_ID
-import com.teamwiney.core.common.util.Constants.FCM_TOKEN
-import com.teamwiney.data.repository.persistence.DataStoreRepository
 import dagger.hilt.android.HiltAndroidApp
-import kotlinx.coroutines.runBlocking
-import javax.inject.Inject
 
 @HiltAndroidApp
 class WineyApp : Application() {
-
-    @Inject
-    lateinit var dataStoreRepository: DataStoreRepository
 
     override fun onCreate() {
         super.onCreate()
         // Kakao SDK 초기화
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
-        fetchAndSetFcmToken()
-        fetchAndSetDeviceId()
-    }
-
-    private fun fetchAndSetDeviceId() {
-        FirebaseInstallations.getInstance().id.addOnCompleteListener { task ->
-            if (task.isSuccessful) {
-                val deviceId = task.result
-                setDeviceId(deviceId)
-                Log.d("FCM", "Fetching instance id succeed : $deviceId")
-            } else {
-                Log.w("FCM", "Fetching instance id failed", task.exception)
-            }
-        }
-    }
-
-    private fun fetchAndSetFcmToken() {
-        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
-            if (task.isSuccessful) {
-                val token = task.result
-                setFcmToken(token)
-                Log.d("FCM", "Fetching FCM registration token succeed : $token")
-            } else {
-                Log.w("FCM", "Fetching FCM registration token failed", task.exception)
-            }
-        }
-    }
-
-    private fun setDeviceId(deviceId: String?) {
-        deviceId?.let {
-            runBlocking {
-                dataStoreRepository.setStringValue(DEVICE_ID, it)
-            }
-        }
-    }
-
-    private fun setFcmToken(token: String?) {
-        token?.let {
-            runBlocking {
-                dataStoreRepository.setStringValue(FCM_TOKEN, it)
-            }
-        }
     }
 }

--- a/app/src/main/java/com/teamwiney/winey/WineyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/teamwiney/winey/WineyFirebaseMessagingService.kt
@@ -11,15 +11,9 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.teamwiney.core.common.util.Constants.FCM_TOKEN
-import com.teamwiney.data.repository.persistence.DataStoreRepository
-import kotlinx.coroutines.runBlocking
-import javax.inject.Inject
 
 class WineyFirebaseMessagingService : FirebaseMessagingService() {
 
-    @Inject
-    lateinit var dataStoreRepository: DataStoreRepository
 
     private val TAG = "fcm"
     private val CHANNEL_ID = "notification_remote_channel"
@@ -29,8 +23,6 @@ class WineyFirebaseMessagingService : FirebaseMessagingService() {
     // Token 생성
     override fun onNewToken(token: String) {
         Log.d(TAG, "new Token: $token")
-
-        runBlocking { dataStoreRepository.setStringValue(FCM_TOKEN, token) }
     }
 
     // foreground 메세지 수신시 동작 설정

--- a/app/src/main/java/com/teamwiney/winey/WineyNavHost.kt
+++ b/app/src/main/java/com/teamwiney/winey/WineyNavHost.kt
@@ -74,7 +74,7 @@ fun WineyNavHost() {
 
             NavHost(
                 modifier = Modifier
-                    .bototmBarPadding(appState.currentDestination, padding),
+                    .bottomBarPadding(appState.currentDestination, padding),
                 navController = navController,
                 startDestination = AuthDestinations.ROUTE
             ) {
@@ -107,7 +107,7 @@ fun WineyNavHost() {
 }
 
 @Composable
-private fun Modifier.Companion.bototmBarPadding(
+private fun Modifier.Companion.bottomBarPadding(
     currentDestination: NavDestination?,
     padding: PaddingValues
 ): Modifier {

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -71,4 +71,7 @@ dependencies {
     implementation(libs.datastore)
     implementation(libs.kakao.sdk.user)
     implementation(libs.play.services.auth)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaing)
 }

--- a/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashContract.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashContract.kt
@@ -12,9 +12,7 @@ class SplashContract {
         val error: String? = null
     ) : UiState
 
-    sealed class Event : UiEvent {
-        object CheckUserStatus : Event()
-    }
+    sealed class Event : UiEvent
 
     sealed class Effect : UiEffect {
         data class NavigateTo(

--- a/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashScreen.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashScreen.kt
@@ -45,8 +45,10 @@ fun SplashScreen(
 
     LaunchedEffect(true) {
         viewModel.checkIsFirstLaunch()
+        viewModel.fetchAndSetDeviceId()
+        viewModel.fetchAndSetFcmToken()
         delay(1500)
-        viewModel.processEvent(SplashContract.Event.CheckUserStatus)
+        viewModel.checkUserStatus()
 
         effectFlow.collectLatest { effect ->
             when (effect) {


### PR DESCRIPTION
## 원인
Application Class나 FirebaseMessagingService에 hilt를 통해 dataStoreRepository를 주입시켰을 때
lateinit property인 dataStoreRepository가 초기화되지 않은 경우가 있어 앱 크래시가 발생했었음

따라서 앱의 첫 시작지점인 스플래시 화면에서 Device Id, Fcm Token을 DataStore에 저장하도록 함
추가로, runBlocking 블록 내에서 Device Id, Fcm Token을 저장할 경우 앱이 스플래시 화면을 벗어나지 않는 버그 발생
-> viewModelScope 내에서 처리하도록 수정

## 변경 사항
* Application 클래스, FirebaseMessagingService 클래스에 dataStoreRepository 주입 제거
* Device Id, Fcm Token 저장 지점을 스플래시 화면으로 설정 