### PR TITLE
[FIX] 회원가입 진행도에 따른 화면 분기 처리

### DIFF
--- a/core/common/src/main/java/com/teamwiney/core/common/model/MessageStatus.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/model/MessageStatus.kt
@@ -1,0 +1,5 @@
+package com.teamwiney.core.common.model
+
+enum class MessageStatus {
+    PENDING, VERIFIED, FAILED, NONE
+}

--- a/core/common/src/main/java/com/teamwiney/core/common/model/PreferenceStatus.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/model/PreferenceStatus.kt
@@ -1,0 +1,5 @@
+package com.teamwiney.core.common.model
+
+enum class PreferenceStatus {
+    DONE, NONE
+}

--- a/data/src/main/java/com/teamwiney/data/network/model/response/SocialLogin.kt
+++ b/data/src/main/java/com/teamwiney/data/network/model/response/SocialLogin.kt
@@ -1,5 +1,7 @@
 package com.teamwiney.data.network.model.response
 
+import com.teamwiney.core.common.model.MessageStatus
+import com.teamwiney.core.common.model.PreferenceStatus
 import com.teamwiney.core.common.model.UserStatus
 
 /**
@@ -24,6 +26,6 @@ data class SocialLogin(
     val userId: Int,
     val refreshToken: String,
     val userStatus: UserStatus,
-    val messageStatus: String,
-    val preferenceStatus: String
+    val messageStatus: MessageStatus,
+    val preferenceStatus: PreferenceStatus
 )

--- a/feature/auth/src/main/java/com/teamwiney/auth/login/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/login/LoginViewModel.kt
@@ -9,6 +9,8 @@ import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 import com.teamwiney.core.common.base.BaseViewModel
+import com.teamwiney.core.common.model.MessageStatus
+import com.teamwiney.core.common.model.PreferenceStatus
 import com.teamwiney.core.common.model.SocialType
 import com.teamwiney.core.common.model.UserStatus
 import com.teamwiney.core.common.navigation.AuthDestinations
@@ -127,6 +129,9 @@ class LoginViewModel @Inject constructor(
                             )
 
                             val userStatus = result.data.result.userStatus
+                            val messageStatus = result.data.result.messageStatus
+                            val preferenceStatus = result.data.result.preferenceStatus
+
                             if (userStatus == UserStatus.ACTIVE) {
                                 dataStoreRepository.setStringValue(LOGIN_TYPE, socialType.name)
 
@@ -141,7 +146,13 @@ class LoginViewModel @Inject constructor(
                                     }
                                 ))
                             } else {
-                                postEffect(LoginContract.Effect.NavigateTo("${AuthDestinations.SignUp.ROUTE}?userId=${result.data.result.userId}"))
+                                if (messageStatus != MessageStatus.VERIFIED) {
+                                    postEffect(LoginContract.Effect.NavigateTo(AuthDestinations.SignUp.ROUTE))
+                                } else if (preferenceStatus != PreferenceStatus.DONE) {
+                                    postEffect(LoginContract.Effect.NavigateTo(AuthDestinations.SignUp.FAVORITE_TASTE))
+                                } else {
+                                    postEffect(LoginContract.Effect.NavigateTo(AuthDestinations.SignUp.ROUTE))
+                                }
                             }
                         }
 

--- a/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpAuthenticationScreen.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpAuthenticationScreen.kt
@@ -50,7 +50,8 @@ import kotlinx.coroutines.flow.collectLatest
 fun SignUpAuthenticationScreen(
     bottomSheetState: WineyBottomSheetState,
     appState: WineyAppState,
-    viewModel: SignUpViewModel = hiltViewModel()
+    viewModel: SignUpViewModel = hiltViewModel(),
+    phoneNumber: String
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val effectFlow = viewModel.effect
@@ -65,6 +66,8 @@ fun SignUpAuthenticationScreen(
     }
 
     LaunchedEffect(true) {
+        viewModel.updatePhoneNumber(phoneNumber)
+
         effectFlow.collectLatest { effect ->
             when (effect) {
                 is SignUpContract.Effect.NavigateTo -> {
@@ -85,7 +88,7 @@ fun SignUpAuthenticationScreen(
                                     sendMessageBottomSheetType = SendMessageBottomSheetType.SEND_MESSAGE
                                 ) {
                                     bottomSheetState.hideBottomSheet()
-                                    appState.navigate(AuthDestinations.SignUp.AUTHENTICATION)
+                                    appState.navigate("${AuthDestinations.SignUp.AUTHENTICATION}?phoneNumber=${uiState.phoneNumber}")
                                 }
                             }
                         }

--- a/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpContract.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpContract.kt
@@ -23,7 +23,6 @@ class SignUpContract {
         val isTimerRunning: Boolean = true,
         val isTimeOut: Boolean = false,
         val remainingTime: Int = VERIFY_NUMBER_TIMER,
-        val userId: String = "",
         val favoriteTastes: List<SignUpFavoriteCategoryUiState> = mutableStateListOf(
             SignUpFavoriteCategoryUiState(
                 title = "평소 초콜릿을 먹을 때 나는?",

--- a/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpNavigation.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpNavigation.kt
@@ -1,10 +1,6 @@
 package com.teamwiney.auth.signup
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
@@ -19,55 +15,39 @@ fun NavGraphBuilder.signUpGraph(
     bottomSheetState: WineyBottomSheetState,
 ) {
     navigation(
-        route = "${AuthDestinations.SignUp.ROUTE}?userId={userId}",
-        startDestination = "${AuthDestinations.SignUp.PHONE}?userId={userId}"
+        route = AuthDestinations.SignUp.ROUTE,
+        startDestination = AuthDestinations.SignUp.PHONE
     ) {
-        composable(
-            route = "${AuthDestinations.SignUp.PHONE}?userId={userId}",
-            arguments = listOf(
-                navArgument("userId") {
-                    type = NavType.StringType
-                    defaultValue = "-1"
-                }
-            )
-        ) { entry ->
-            val userId = entry.arguments?.getString("userId") ?: ""
-            val backStackEntry = rememberNavControllerBackStackEntry(
-                entry = entry,
-                navController = appState.navController,
-                graph = "${AuthDestinations.SignUp.PHONE}?userId={userId}"
-            )
+        composable(route = AuthDestinations.SignUp.PHONE) {
             SignUpPhoneScreen(
                 bottomSheetState = bottomSheetState,
                 appState = appState,
-                userId = userId,
-                viewModel = hiltViewModel(backStackEntry)
+                viewModel = hiltViewModel()
             )
         }
 
-        composable(route = AuthDestinations.SignUp.AUTHENTICATION) {
-            val backStackEntry = rememberNavControllerBackStackEntry(
-                entry = it,
-                navController = appState.navController,
-                graph = "${AuthDestinations.SignUp.PHONE}?userId={userId}"
+        composable(route = "${AuthDestinations.SignUp.AUTHENTICATION}?phoneNumber={phoneNumber}",
+            arguments = listOf(
+                navArgument("phoneNumber") {
+                    type = NavType.StringType
+                    defaultValue = ""
+                }
             )
+        ) { entry ->
+            val phoneNumber = entry.arguments?.getString("phoneNumber") ?: ""
             SignUpAuthenticationScreen(
                 bottomSheetState = bottomSheetState,
                 appState = appState,
-                viewModel = hiltViewModel(backStackEntry)
+                viewModel = hiltViewModel(),
+                phoneNumber = phoneNumber
             )
         }
 
         composable(route = AuthDestinations.SignUp.FAVORITE_TASTE) {
-            val backStackEntry = rememberNavControllerBackStackEntry(
-                entry = it,
-                navController = appState.navController,
-                graph = "${AuthDestinations.SignUp.PHONE}?userId={userId}"
-            )
             SignUpFavoriteTasteScreen(
                 bottomSheetState = bottomSheetState,
                 appState = appState,
-                viewModel = hiltViewModel(backStackEntry)
+                viewModel = hiltViewModel()
             )
         }
 
@@ -75,13 +55,4 @@ fun NavGraphBuilder.signUpGraph(
             SignUpCompleteScreen(appState = appState)
         }
     }
-}
-
-@Composable
-fun rememberNavControllerBackStackEntry(
-    entry: NavBackStackEntry,
-    navController: NavController,
-    graph: String,
-) = remember(entry) {
-    navController.getBackStackEntry(graph)
 }

--- a/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpPhoneScreen.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpPhoneScreen.kt
@@ -49,17 +49,15 @@ import kotlinx.coroutines.flow.collectLatest
 fun SignUpPhoneScreen(
     appState: WineyAppState,
     bottomSheetState: WineyBottomSheetState,
-    viewModel: SignUpViewModel = hiltViewModel(),
-    userId: String = "",
+    viewModel: SignUpViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val effectFlow = viewModel.effect
 
     DisposableEffect(true) {
-        viewModel.updateUserId(userId)
         bottomSheetState.setOnHideBottomSheet {
             bottomSheetState.hideBottomSheet()
-            appState.navigate(AuthDestinations.SignUp.AUTHENTICATION)
+            appState.navigate("${AuthDestinations.SignUp.AUTHENTICATION}?phoneNumber=${uiState.phoneNumber}")
         }
         onDispose {
             bottomSheetState.setOnHideBottomSheet { }
@@ -82,7 +80,7 @@ fun SignUpPhoneScreen(
                                     sendMessageBottomSheetType = SendMessageBottomSheetType.SEND_MESSAGE
                                 ) {
                                     bottomSheetState.hideBottomSheet()
-                                    appState.navigate(AuthDestinations.SignUp.AUTHENTICATION)
+                                    appState.navigate("${AuthDestinations.SignUp.AUTHENTICATION}?phoneNumber=${uiState.phoneNumber}")
                                 }
                             }
                         }

--- a/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpViewModel.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/signup/SignUpViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 @HiltViewModel
@@ -52,8 +53,10 @@ class SignUpViewModel @Inject constructor(
     }
 
     private fun setPreferences() = viewModelScope.launch {
+        val userId = runBlocking { dataStoreRepository.getIntValue(Constants.USER_ID).first() }
+
         authRepository.setPreferences(
-            userId = currentState.userId,
+            userId = "$userId",
             request = SetPreferencesRequest(
                 chocolate = currentState.favoriteTastes[0].signUpFavoriteItem.find { it.isSelected }?.keyword!!,
                 coffee = currentState.favoriteTastes[1].signUpFavoriteItem.find { it.isSelected }?.keyword!!,
@@ -81,8 +84,10 @@ class SignUpViewModel @Inject constructor(
     }
 
     private fun verifyAuthenticationNumber() = viewModelScope.launch {
+        val userId = runBlocking { dataStoreRepository.getIntValue(Constants.USER_ID).first() }
+
         authRepository.verifyAuthCodeMessage(
-            currentState.userId,
+            "$userId",
             PhoneNumberWithVerificationCodeRequest(
                 phoneNumber = currentState.phoneNumber,
                 verificationCode = currentState.verifyNumber
@@ -124,8 +129,10 @@ class SignUpViewModel @Inject constructor(
     }
 
     private fun sendAuthenticationNumber() = viewModelScope.launch {
+        val userId = runBlocking { dataStoreRepository.getIntValue(Constants.USER_ID).first() }
+
         authRepository.sendAuthCodeMessage(
-            currentState.userId,
+            "$userId",
             PhoneNumberRequest(
                 currentState.phoneNumber
             )
@@ -201,10 +208,6 @@ class SignUpViewModel @Inject constructor(
                 else -> { }
             }
         }
-    }
-
-    fun updateUserId(userId: String) = viewModelScope.launch {
-        updateState(currentState.copy(userId = userId))
     }
 
     fun updatePhoneNumber(phoneNumber: String) = viewModelScope.launch {


### PR DESCRIPTION
## 변경사항
기존에 userStatus 만 보고서 회원가입 판단을 했기 때문에 `ACTIVE` 일 시 홈, `INACTIVE` 일 시 로그인으로 보내주었습니다.
그치만 회원가입을 중간에 못 마친 경우, 해당 화면으로 보내주어야 하기 때문에 `messageStatus`, `preferenceStatus` 를 통해 마지막으로 회원가입을 진행한 화면으로 돌아가도록 분기 처리를 해주었습니다.

추가적으로, 코드 구조적으로는 이제 회원가입 과정이 하나의 뷰모델을 공유하지 않습니다.