### PR TITLE
[FEAT] 액세스 토큰 만료 시 로그인 화면으로 이동

### DIFF
--- a/app/src/main/java/com/teamwiney/winey/MainActivity.kt
+++ b/app/src/main/java/com/teamwiney/winey/MainActivity.kt
@@ -7,11 +7,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
+import com.teamwiney.core.common.rememberWineyAppState
+import com.teamwiney.core.common.rememberWineyBottomSheetState
 import com.teamwiney.ui.theme.WineyTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // WindowInset 직접 조절하기 위해서
@@ -22,7 +25,10 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = WineyTheme.colors.background_1
                 ) {
-                    WineyNavHost()
+                    WineyNavHost(
+                        appState = rememberWineyAppState(),
+                        bottomSheetState = rememberWineyBottomSheetState()
+                    )
                 }
             }
         }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -55,4 +55,5 @@ dependencies {
     implementation(libs.datastore)
     implementation(libs.compose.paging)
     implementation(libs.bundles.network)
+    implementation(libs.local.broadcast.manager)
 }

--- a/data/src/main/java/com/teamwiney/data/network/interceptor/AuthInterceptor.kt
+++ b/data/src/main/java/com/teamwiney/data/network/interceptor/AuthInterceptor.kt
@@ -1,6 +1,8 @@
 package com.teamwiney.data.network.interceptor
 
 import android.content.Context
+import android.content.Intent
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.teamwiney.core.common.base.CommonResponse
 import com.teamwiney.core.common.util.Constants.ACCESS_TOKEN
@@ -54,6 +56,11 @@ class AuthInterceptor @Inject constructor(
                     runBlocking {
                         dataStoreRepository.deleteStringValue(ACCESS_TOKEN)
                         dataStoreRepository.deleteStringValue(REFRESH_TOKEN)
+                    }
+
+                    // 리프레시 토큰을 통한 갱신 실패 시
+                    Intent("com.teamwiney.winey.TOKEN_EXPIRED").also { intent ->
+                        LocalBroadcastManager.getInstance(context).sendBroadcast(intent)
                     }
                 }
             }

--- a/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashViewModel.kt
+++ b/feature/auth/src/main/java/com/teamwiney/auth/splash/SplashViewModel.kt
@@ -112,6 +112,7 @@ class SplashViewModel @Inject constructor(
 
                 is ApiResult.NetworkError -> {
                     postEffect(SplashContract.Effect.ShowSnackBar("네트워크 오류가 발생했습니다."))
+                    navigateToMain()
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ agp_version = "8.0.2"
 browser_version = "1.7.0"
 kotlin_version = "1.8.10"
 android_core_ktx_version = "1.10.1"
+local_broadcast_manager_version = "1.0.0"
 activity_compose_version = "1.7.2"
 tools_build_gradle_version = "8.0.2"
 compose_coil_version = "2.2.2"
@@ -35,6 +36,7 @@ firebase_crashlytics_version = "2.9.9"
 
 [libraries]
 android_core_ktx = { module = "androidx.core:core-ktx", version.ref = "android_core_ktx_version" }
+local_broadcast_manager = { module = "androidx.localbroadcastmanager:localbroadcastmanager", version.ref = "local_broadcast_manager_version" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat_version" }
 activity_compose = { module = "androidx.activity:activity-compose", version.ref = "activity_compose_version" }
 browser = { module = "androidx.browser:browser", version.ref = "browser_version" }


### PR DESCRIPTION
## 변경사항
* 리프레시 API를 통해 액세트 토큰 갱신 실패 시 브로드캐스트 인텐트 방출

```kotlin
when (response.code) {
    401 -> {
        val newToken = runBlocking { updateToken(refreshToken, context) }

        if (newToken.isSuccessful) {
            val newAccessToken = newToken.body()?.result?.accessToken ?: ""

            runBlocking { dataStoreRepository.setStringValue(ACCESS_TOKEN, newAccessToken) }

            val newAuthenticationRequest = originalRequest.newBuilder()
                .header("X-AUTH-TOKEN", newAccessToken)
                .build()

            return chain.proceed(newAuthenticationRequest)
        } else {
            runBlocking {
                dataStoreRepository.deleteStringValue(ACCESS_TOKEN)
                dataStoreRepository.deleteStringValue(REFRESH_TOKEN)
            }

            // 리프레시 토큰을 통한 갱신 실패 시
            Intent("com.teamwiney.winey.TOKEN_EXPIRED").also { intent ->
                LocalBroadcastManager.getInstance(context).sendBroadcast(intent)
            }
        }
    }
}
```

* NavHost 최상단에 토큰 만료 시 로그인 화면으로 돌아가도록 브로드캐스트 리시버 부착

```kotlin
@Composable
fun TokenExpiredBroadcastReceiver(
    onExpired: (intent: Intent?) -> Unit
) {
    val context = LocalContext.current

    val currentOnExpired by rememberUpdatedState(onExpired)

    DisposableEffect(context) {
        val intentFilter = IntentFilter("com.teamwiney.winey.TOKEN_EXPIRED")
        val broadcast = object : BroadcastReceiver() {
            override fun onReceive(context: Context?, intent: Intent?) {
                currentOnExpired(intent)
            }
        }

        LocalBroadcastManager.getInstance(context).registerReceiver(broadcast, intentFilter)
        Log.d("debugging", "리시버 부착")

        onDispose {
            context.unregisterReceiver(broadcast)
            Log.d("debugging", "리시버 부착 해제")
        }
    }
}

@OptIn(ExperimentalMaterialApi::class)
@Composable
fun WineyNavHost(
    appState: WineyAppState,
    bottomSheetState: WineyBottomSheetState
) {
    val navController = appState.navController

    TokenExpiredBroadcastReceiver { intent ->
        if (intent?.action == "com.teamwiney.winey.TOKEN_EXPIRED") {
            appState.showSnackbar("토큰이 만료되었습니다. 다시 로그인해주세요.")
            appState.navController.navigate(
                AuthDestinations.Login.LOGIN,
                navOptions {
                    popUpTo(AuthDestinations.Login.LOGIN) {
                        inclusive = true
                    }
                }
            )
        }
    }
    //...
}

```

## 논의점
* `LocalBroadcastManager.getInstance(context)` 를 써야만 작동하는 이유??
