### PR TITLE
[REFACTOR] NetworkMonitor 도입 및 인터페이스 주입 Binds 로 변경

### DIFF
--- a/app/src/main/java/com/teamwiney/winey/MainActivity.kt
+++ b/app/src/main/java/com/teamwiney/winey/MainActivity.kt
@@ -7,13 +7,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
+import com.teamwiney.core.common.NetworkMonitor
 import com.teamwiney.core.common.rememberWineyAppState
 import com.teamwiney.core.common.rememberWineyBottomSheetState
 import com.teamwiney.ui.theme.WineyTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var networkMonitor: NetworkMonitor
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,7 +31,9 @@ class MainActivity : ComponentActivity() {
                     color = WineyTheme.colors.background_1
                 ) {
                     WineyNavHost(
-                        appState = rememberWineyAppState(),
+                        appState = rememberWineyAppState(
+                            networkMonitor = networkMonitor
+                        ),
                         bottomSheetState = rememberWineyBottomSheetState()
                     )
                 }

--- a/app/src/main/java/com/teamwiney/winey/WineyNavHost.kt
+++ b/app/src/main/java/com/teamwiney/winey/WineyNavHost.kt
@@ -16,16 +16,20 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Snackbar
+import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.navigation.NavDestination
 import androidx.navigation.NavType
@@ -84,6 +88,17 @@ fun WineyNavHost(
     bottomSheetState: WineyBottomSheetState
 ) {
     val navController = appState.navController
+
+    val isOffline by appState.isOffline.collectAsStateWithLifecycle()
+
+    LaunchedEffect(isOffline) {
+        if (isOffline) {
+            appState.scaffoldState.snackbarHostState.showSnackbar(
+                message = "⚠\uFE0F 인터넷에 연결되어 있지 않습니다.",
+                duration = SnackbarDuration.Indefinite
+            )
+        }
+    }
 
     TokenExpiredBroadcastReceiver { intent ->
         if (intent?.action == "com.teamwiney.winey.TOKEN_EXPIRED") {

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -4,6 +4,8 @@ import java.util.Properties
 plugins {
     id(libs.plugins.android.library.get().pluginId)
     id(libs.plugins.jetbrains.kotlin.android.get().pluginId)
+    id(libs.plugins.dagger.hilt.android.get().pluginId)
+    id(libs.plugins.kotlin.kapt.get().pluginId)
 }
 
 val properties = Properties().apply {
@@ -24,7 +26,6 @@ android {
         )
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
     }
     buildFeatures {
         compose = true
@@ -42,11 +43,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }
 
@@ -61,5 +62,9 @@ dependencies {
     implementation(libs.coroutines.android)
     implementation(libs.lifecycle.runtime.viewmodel)
     implementation(libs.converter.gson)
+
     implementation(libs.datastore)
+    implementation(libs.dagger)
+    implementation(libs.hilt.android)
+    kapt(libs.hilt.android.compiler)
 }

--- a/core/common/src/main/AndroidManifest.xml
+++ b/core/common/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/core/common/src/main/java/com/teamwiney/core/common/ConnectivityManagerNetworkMonitor.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/ConnectivityManagerNetworkMonitor.kt
@@ -1,0 +1,84 @@
+package com.teamwiney.core.common
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Build
+import android.util.Log
+import androidx.core.content.getSystemService
+import com.teamwiney.core.common.di.DispatcherModule
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+interface NetworkMonitor {
+    val isOnline: Flow<Boolean>
+}
+
+class ConnectivityManagerNetworkMonitor @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @DispatcherModule.IoDispatcher private val ioDispatcher: CoroutineDispatcher
+): NetworkMonitor {
+    override val isOnline: Flow<Boolean> = callbackFlow {
+        val connectivityManager = context.getSystemService<ConnectivityManager>()
+        if (connectivityManager == null) {
+            trySend(false)
+            close()
+            return@callbackFlow
+        }
+
+        val callback = object : NetworkCallback() {
+
+            private val networks = mutableSetOf<Network>()
+
+            override fun onAvailable(network: Network) {
+                networks += network
+                trySend(true)
+
+                Log.d("NetworkMonitor", "Network available")
+            }
+
+            override fun onLost(network: Network) {
+                networks -= network
+                trySend(networks.isNotEmpty())
+
+                Log.d("NetworkMonitor", "Network lost")
+            }
+        }
+
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        connectivityManager.registerNetworkCallback(request, callback)
+
+        trySend(connectivityManager.isCurrentlyConnected())
+
+        awaitClose {
+            connectivityManager.unregisterNetworkCallback(callback)
+        }
+    }
+        .flowOn(ioDispatcher)
+        .conflate()
+
+    private fun ConnectivityManager.isCurrentlyConnected(): Boolean {
+        return try {
+            activeNetwork
+                ?.let(::getNetworkCapabilities)
+                ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                ?: false
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+}

--- a/core/common/src/main/java/com/teamwiney/core/common/di/DispatcherModule.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/di/DispatcherModule.kt
@@ -1,4 +1,4 @@
-package com.teamwiney.data.di
+package com.teamwiney.core.common.di
 
 import dagger.Module
 import dagger.Provides

--- a/core/common/src/main/java/com/teamwiney/core/common/di/NetworkMonitorModule.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/di/NetworkMonitorModule.kt
@@ -13,13 +13,11 @@ import kotlinx.coroutines.CoroutineDispatcher
 
 @Module
 @InstallIn(SingletonComponent::class)
-object NetworkMonitorModule {
+abstract class NetworkMonitorModule {
 
-    @Provides
-    fun providesNetworkMonitor(
-        @ApplicationContext context: Context,
-        @DispatcherModule.IoDispatcher ioDispatcher: CoroutineDispatcher
-    ): NetworkMonitor =
-        ConnectivityManagerNetworkMonitor(context, ioDispatcher)
+    @Binds
+    abstract fun bindsNetworkMonitor(
+        networkMonitor: ConnectivityManagerNetworkMonitor
+    ): NetworkMonitor
 
 }

--- a/core/common/src/main/java/com/teamwiney/core/common/di/NetworkMonitorModule.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/di/NetworkMonitorModule.kt
@@ -1,0 +1,25 @@
+package com.teamwiney.core.common.di
+
+import android.content.Context
+import com.teamwiney.core.common.ConnectivityManagerNetworkMonitor
+import com.teamwiney.core.common.NetworkMonitor
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkMonitorModule {
+
+    @Provides
+    fun providesNetworkMonitor(
+        @ApplicationContext context: Context,
+        @DispatcherModule.IoDispatcher ioDispatcher: CoroutineDispatcher
+    ): NetworkMonitor =
+        ConnectivityManagerNetworkMonitor(context, ioDispatcher)
+
+}

--- a/core/design/build.gradle.kts
+++ b/core/design/build.gradle.kts
@@ -26,11 +26,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true

--- a/data/src/main/java/com/teamwiney/data/datasource/auth/AuthDataSourceImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/datasource/auth/AuthDataSourceImpl.kt
@@ -1,7 +1,7 @@
 package com.teamwiney.data.datasource.auth
 
 import com.teamwiney.core.common.model.SocialType
-import com.teamwiney.data.di.DispatcherModule
+import com.teamwiney.core.common.di.DispatcherModule
 import com.teamwiney.data.network.model.request.FcmTokenRequest
 import com.teamwiney.data.network.model.request.GoogleAccessTokenRequest
 import com.teamwiney.data.network.model.request.PhoneNumberRequest

--- a/data/src/main/java/com/teamwiney/data/datasource/map/MapDataSourceImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/datasource/map/MapDataSourceImpl.kt
@@ -1,7 +1,7 @@
 package com.teamwiney.data.datasource.map
 
 import com.teamwiney.core.common.base.CommonResponse
-import com.teamwiney.data.di.DispatcherModule
+import com.teamwiney.core.common.di.DispatcherModule
 import com.teamwiney.data.network.adapter.ApiResult
 import com.teamwiney.data.network.model.request.MapPosition
 import com.teamwiney.data.network.model.response.BookmarkResult

--- a/data/src/main/java/com/teamwiney/data/datasource/tastingnote/TastingNoteDataSourceImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/datasource/tastingnote/TastingNoteDataSourceImpl.kt
@@ -2,7 +2,7 @@ package com.teamwiney.data.datasource.tastingnote
 
 import com.teamwiney.core.common.base.CommonResponse
 import com.teamwiney.core.common.`typealias`.BaseResponse
-import com.teamwiney.data.di.DispatcherModule
+import com.teamwiney.core.common.di.DispatcherModule
 import com.teamwiney.data.network.adapter.ApiResult
 import com.teamwiney.data.network.model.response.PagingResponse
 import com.teamwiney.data.network.model.response.TasteAnalysis

--- a/data/src/main/java/com/teamwiney/data/datasource/wine/WineDataSourceImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/datasource/wine/WineDataSourceImpl.kt
@@ -1,7 +1,7 @@
 package com.teamwiney.data.datasource.wine
 
 import com.teamwiney.core.common.base.CommonResponse
-import com.teamwiney.data.di.DispatcherModule
+import com.teamwiney.core.common.di.DispatcherModule
 import com.teamwiney.data.network.adapter.ApiResult
 import com.teamwiney.data.network.model.response.PagingResponse
 import com.teamwiney.data.network.model.response.SearchWine

--- a/data/src/main/java/com/teamwiney/data/datasource/winebadge/WineBadgeDataSourceImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/datasource/winebadge/WineBadgeDataSourceImpl.kt
@@ -1,6 +1,6 @@
 package com.teamwiney.data.datasource.winebadge
 
-import com.teamwiney.data.di.DispatcherModule
+import com.teamwiney.core.common.di.DispatcherModule
 import com.teamwiney.data.network.service.WineBadgeService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.flow

--- a/data/src/main/java/com/teamwiney/data/datasource/winegrade/WineGradeDataSourceImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/datasource/winegrade/WineGradeDataSourceImpl.kt
@@ -1,6 +1,6 @@
 package com.teamwiney.data.datasource.winegrade
 
-import com.teamwiney.data.di.DispatcherModule
+import com.teamwiney.core.common.di.DispatcherModule
 import com.teamwiney.data.network.service.WineGradeService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.flow

--- a/data/src/main/java/com/teamwiney/data/di/DataModule.kt
+++ b/data/src/main/java/com/teamwiney/data/di/DataModule.kt
@@ -36,6 +36,7 @@ import com.teamwiney.data.repository.winebadge.WineBadgeRepository
 import com.teamwiney.data.repository.winebadge.WineBadgeRepositoryImpl
 import com.teamwiney.data.repository.winegrade.WineGradeRepository
 import com.teamwiney.data.repository.winegrade.WineGradeRepositoryImpl
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -46,94 +47,70 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object DataModule {
+abstract class DataModule {
 
-    @Provides
-    @Singleton
-    fun providesAuthDataSource(
-        authService: AuthService,
-        @DispatcherModule.IoDispatcher ioDispatcher: CoroutineDispatcher
-    ): AuthDataSource =
-        AuthDataSourceImpl(authService, ioDispatcher)
+    @Binds
+    abstract fun bindsAuthDataSource(
+        authDataSource: AuthDataSourceImpl
+    ): AuthDataSource
 
-    @Provides
-    @Singleton
-    fun providesWineDataSource(
-        wineService: WineService,
-        @DispatcherModule.IoDispatcher ioDispatcher: CoroutineDispatcher
-    ): WineDataSource =
-        WineDataSourceImpl(wineService, ioDispatcher)
+    @Binds
+    abstract fun bindsWineDataSource(
+        wineDataSource: WineDataSourceImpl
+    ): WineDataSource
 
-    @Provides
-    @Singleton
-    fun providesTastingNoteDataSource(
-        tastingNoteService: TastingNoteService,
-        @DispatcherModule.IoDispatcher ioDispatcher: CoroutineDispatcher
-    ): TastingNoteDataSource =
-        TastingNoteDataSourceImpl(tastingNoteService, ioDispatcher)
+    @Binds
+    abstract fun bindsTastingNoteDataSource(
+        tastingNoteDataSource: TastingNoteDataSourceImpl
+    ): TastingNoteDataSource
 
-    @Provides
-    @Singleton
-    fun providesWineGradeDataSource(
-        wineGradeService: WineGradeService,
-        @DispatcherModule.IoDispatcher ioDispatcher: CoroutineDispatcher
-    ): WineGradeDataSource =
-        WineGradeDataSourceImpl(wineGradeService, ioDispatcher)
+    @Binds
+    abstract fun bindsWineGradeDataSource(
+        wineGradeDataSource: WineGradeDataSourceImpl
+    ): WineGradeDataSource
 
-    @Provides
-    @Singleton
-    fun providesWineBadgeDataSource(
-        wineBadgeService: WineBadgeService,
-        @DispatcherModule.IoDispatcher ioDispatcher: CoroutineDispatcher
-    ): WineBadgeDataSource =
-        WineBadgeDataSourceImpl(wineBadgeService, ioDispatcher)
+    @Binds
+    abstract fun bindsWineBadgeDataSource(
+        wineBadgeDataSource: WineBadgeDataSourceImpl
+    ): WineBadgeDataSource
 
-    @Provides
-    @Singleton
-    fun providesMapDataSource(
-        mapService: MapService,
-        @DispatcherModule.IoDispatcher ioDispatcher: CoroutineDispatcher
-    ): MapDataSource =
-        MapDataSourceImpl(mapService, ioDispatcher)
+    @Binds
+    abstract fun bindsMapDataSource(
+        mapDataSource: MapDataSourceImpl
+    ): MapDataSource
 
-    @Provides
-    @Singleton
-    fun providesAuthRepository(authDataSource: AuthDataSource): AuthRepository =
-        AuthRepositoryImpl(authDataSource)
+    @Binds
+    abstract fun bindsAuthRepository(
+        authRepository: AuthRepositoryImpl
+    ): AuthRepository
 
-    @Provides
-    @Singleton
-    fun providesWineRepository(wineDataSource: WineDataSource): WineRepository =
-        WineRepositoryImpl(wineDataSource)
+    @Binds
+    abstract fun bindsWineRepository(
+        wineRepository: WineRepositoryImpl
+    ): WineRepository
 
-    @Provides
-    @Singleton
-    fun providesTastingNotRepository(
-        tastingNoteDataSource: TastingNoteDataSource,
-        @ApplicationContext context: Context
-    ): TastingNoteRepository = TastingNoteRepositoryImpl(tastingNoteDataSource, context)
+    @Binds
+    abstract fun bindsTastingNoteRepository(
+        tastingNoteRepository: TastingNoteRepositoryImpl
+    ): TastingNoteRepository
 
-    @Provides
-    @Singleton
-    fun providesDataStoreRepository(
-        pref: DataStore<Preferences>
-    ): DataStoreRepository = DataStoreRepositoryImpl(pref)
+    @Binds
+    abstract fun bindsDataStoreRepository(
+        dataStoreRepository: DataStoreRepositoryImpl
+    ): DataStoreRepository
 
-    @Provides
-    @Singleton
-    fun providesWineGradeRepository(
-        wineGradeDataSource: WineGradeDataSource
-    ): WineGradeRepository = WineGradeRepositoryImpl(wineGradeDataSource)
+    @Binds
+    abstract fun bindsWineGradeRepository(
+        wineGradeRepository: WineGradeRepositoryImpl
+    ): WineGradeRepository
 
-    @Provides
-    @Singleton
-    fun providesWineBadgeRepository(
-        wineBadgeDataSource: WineBadgeDataSource
-    ): WineBadgeRepository = WineBadgeRepositoryImpl(wineBadgeDataSource)
+    @Binds
+    abstract fun bindsWineBadgeRepository(
+        wineBadgeRepository: WineBadgeRepositoryImpl
+    ): WineBadgeRepository
 
-    @Provides
-    @Singleton
-    fun providesMapRepository(
-        mapDataSource: MapDataSource
-    ): MapRepository = MapRepositoryImpl(mapDataSource)
+    @Binds
+    abstract fun bindsMapRepository(
+        mapRepository: MapRepositoryImpl
+    ): MapRepository
 }

--- a/data/src/main/java/com/teamwiney/data/di/DataModule.kt
+++ b/data/src/main/java/com/teamwiney/data/di/DataModule.kt
@@ -3,6 +3,7 @@ package com.teamwiney.data.di
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import com.teamwiney.core.common.di.DispatcherModule
 import com.teamwiney.data.datasource.auth.AuthDataSource
 import com.teamwiney.data.datasource.auth.AuthDataSourceImpl
 import com.teamwiney.data.datasource.map.MapDataSource

--- a/data/src/main/java/com/teamwiney/data/repository/persistence/DataStoreRepositoryImpl.kt
+++ b/data/src/main/java/com/teamwiney/data/repository/persistence/DataStoreRepositoryImpl.kt
@@ -8,8 +8,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import java.io.IOException
+import javax.inject.Inject
 
-class DataStoreRepositoryImpl(
+class DataStoreRepositoryImpl @Inject constructor(
     private val preferenceDataStore: DataStore<Preferences>,
 ) : DataStoreRepository {
 

--- a/feature/home/src/main/java/com/teamwiney/home/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/teamwiney/home/HomeNavigation.kt
@@ -45,8 +45,6 @@ fun NavGraphBuilder.homeGraph(
             )
         }
 
- 
-
         composable(
             route = "${HomeDestinations.WINE_DETAIL}?id={wineId}",
             arguments = listOf(


### PR DESCRIPTION
# 변경사항

## 1. 네트워크 모니터를 통한 실시간 네트워크 상태 체크

```kotlin
class ConnectivityManagerNetworkMonitor @Inject constructor(
    @ApplicationContext private val context: Context,
    @DispatcherModule.IoDispatcher private val ioDispatcher: CoroutineDispatcher
): NetworkMonitor {
    override val isOnline: Flow<Boolean> = callbackFlow {
        val connectivityManager = context.getSystemService<ConnectivityManager>()
        if (connectivityManager == null) {
            trySend(false)
            close()
            return@callbackFlow
        }

        val callback = object : NetworkCallback() {

            private val networks = mutableSetOf<Network>()

            override fun onAvailable(network: Network) {
                networks += network
                trySend(true)

                Log.d("NetworkMonitor", "Network available")
            }

            override fun onLost(network: Network) {
                networks -= network
                trySend(networks.isNotEmpty())

                Log.d("NetworkMonitor", "Network lost")
            }
        }

        val request = NetworkRequest.Builder()
            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
            .build()
        connectivityManager.registerNetworkCallback(request, callback)

        trySend(connectivityManager.isCurrentlyConnected())

        awaitClose {
            connectivityManager.unregisterNetworkCallback(callback)
        }
    }
        .flowOn(ioDispatcher)
        .conflate()

    private fun ConnectivityManager.isCurrentlyConnected(): Boolean {
        return try {
            activeNetwork
                ?.let(::getNetworkCapabilities)
                ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                ?: false
        } catch (e: Exception) {
            e.printStackTrace()
            false
        }
    }
}
```

callback 에서 데이터를 받고, 이 데이터를 실시간으로 `Flow` 컬렉터에게 보내는 `callbackFlow` 를 사용
네트워크 상태 감지를 callback 을 통해서 하기 때문에 callbackFlow 로 구현
conflate() 연산자를 통해서 마지막으로 발행한 네트워크 상태값을 사용하도록 함

## 2. 인터페이스 주입을 Provides -> Binds 로 변경

### Provides

특정 타입의 객체를 생성하는 방법을 Dagger에게 알려줄 때 사용
생성자에 `@Inject` 를 사용할 수 없거나, 객체 생성 과정이 복잡할 때 사용
예를 들어 외부 라이브러리의 객체 (e.g. 레트로핏) 나 특정 구성을 필요로 하는 객체 제공

```kotlin
@Provides
    @Singleton
    fun providesRetrofit(okHttpClient: OkHttpClient): Retrofit =
        Retrofit.Builder()
            .client(okHttpClient)
            .baseUrl(BuildConfig.BASE_URL)
            .addCallAdapterFactory(ApiResultCallAdapterFactory())
            .addConverterFactory(EnumConverterFactory())
            .addConverterFactory(GsonConverterFactory.create())
            .build()
```

### Binds

하나의 인터페이스 또는 추상 클래스를 그 구현체에 바인딩하는 데 사용
**@Provides 보다 효율적인 코드 생성**
이미 생성자에게 `@Inject` 가 사용되어 의존성 주입이 준비된 객체를 인터페이스에 바인딩

```kotlin
@Module
@InstallIn(SingletonComponent::class)
abstract class DataModule {

    @Binds
    abstract fun bindsAuthDataSource(
        authDataSource: AuthDataSourceImpl
    ): AuthDataSource

    @Binds
    abstract fun bindsWineDataSource(
        wineDataSource: WineDataSourceImpl
    ): WineDataSource

    @Binds
    abstract fun bindsTastingNoteDataSource(
        tastingNoteDataSource: TastingNoteDataSourceImpl
    ): TastingNoteDataSource

    @Binds
    abstract fun bindsWineGradeDataSource(
        wineGradeDataSource: WineGradeDataSourceImpl
    ): WineGradeDataSource

    @Binds
    abstract fun bindsWineBadgeDataSource(
        wineBadgeDataSource: WineBadgeDataSourceImpl
    ): WineBadgeDataSource
//...
```
Data Layer 단의 DataSource나 Repository는 굳이 Provides 사용할 이유가 없음
->  이미 생성자에게 `@Inject` 가 사용되어 의존성 주입이 준비됨
따라서, `@Binds` 로 교체