### PR TITLE
[FEAT] Amplitude 이벤트 수집 - 홈 탭

### DIFF
--- a/app/src/main/java/com/teamwiney/winey/WineyApp.kt
+++ b/app/src/main/java/com/teamwiney/winey/WineyApp.kt
@@ -2,7 +2,7 @@ package com.teamwiney.winey
 
 import android.app.Application
 import com.kakao.sdk.common.KakaoSdk
-import com.teamwiney.core.common.di.AmplitudeProvider
+import com.teamwiney.core.common.AmplitudeProvider
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp

--- a/core/common/src/main/java/com/teamwiney/core/common/AmplitudeEvent.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/AmplitudeEvent.kt
@@ -1,0 +1,11 @@
+package com.teamwiney.core.common
+
+enum class AmplitudeEvent {
+    HOME_ENTER,
+    WINE_DETAIL_CLICK,
+    ANALYZE_BUTTON_CLICK,
+    TIP_POST_CLICK;
+
+    val eventName: String
+        get() = name
+}

--- a/core/common/src/main/java/com/teamwiney/core/common/AmplitudeProvider.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/AmplitudeProvider.kt
@@ -1,11 +1,10 @@
-package com.teamwiney.core.common.di
+package com.teamwiney.core.common
 
 import android.content.Context
 import com.amplitude.android.Amplitude
 import com.amplitude.android.Configuration
 import com.amplitude.android.DefaultTrackingOptions
 import com.amplitude.android.utilities.AndroidLoggerProvider
-import com.teamwiney.core.common.BuildConfig
 
 object AmplitudeProvider {
     private var amplitude: Amplitude? = null
@@ -25,7 +24,7 @@ object AmplitudeProvider {
         return amplitude ?: throw IllegalStateException("Amplitude is not initialized")
     }
 
-    fun trackEvent(eventName: String) {
-        getAmplitude().track(eventName)
+    fun trackEvent(event: AmplitudeEvent) {
+        getAmplitude().track(event.eventName)
     }
 }

--- a/core/common/src/main/java/com/teamwiney/core/common/navigation/Destinations.kt
+++ b/core/common/src/main/java/com/teamwiney/core/common/navigation/Destinations.kt
@@ -17,7 +17,6 @@ object AuthDestinations {
         const val PHONE = "signUpPhone"
         const val AUTHENTICATION = "signUpAuthentication"
         const val FAVORITE_TASTE = "signUpFavoriteTaste"
-        const val TASTE_RESULT = "signUpTasteResult"
         const val COMPLETE = "signUpComplete"
     }
 }

--- a/feature/home/src/main/java/com/teamwiney/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teamwiney/home/HomeScreen.kt
@@ -50,6 +50,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
 import com.teamwiney.analysis.component.TipCard
+import com.teamwiney.core.common.AmplitudeEvent
 import com.teamwiney.core.common.WineyAppState
 import com.teamwiney.core.common.AmplitudeProvider
 import com.teamwiney.core.common.navigation.HomeDestinations
@@ -73,6 +74,10 @@ fun HomeScreen(
 
     val wineTips = uiState.wineTips.collectAsLazyPagingItems()
     val wineTipsRefreshState = wineTips.loadState.refresh
+
+    LaunchedEffect(true) {
+        AmplitudeProvider.trackEvent(AmplitudeEvent.HOME_ENTER)
+    }
 
     LaunchedEffect(wineTipsRefreshState) {
         if (wineTipsRefreshState is LoadState.Error) {
@@ -111,7 +116,7 @@ fun HomeScreen(
         HomeLogo(
             onClick = {
                 viewModel.processEvent(HomeContract.Event.ShowAnalysis)
-                AmplitudeProvider.trackEvent("analysis_button_click")
+                AmplitudeProvider.trackEvent(AmplitudeEvent.ANALYZE_BUTTON_CLICK)
             },
             hintPopupOpen = uiState.isFirstScroll
         )
@@ -194,6 +199,7 @@ fun HomeWineTips(
                         thumbnail = it.thumbnail,
                         onClick = {
                             viewModel.processEvent(HomeContract.Event.ShowTipDetail(it.url))
+                            AmplitudeProvider.trackEvent(AmplitudeEvent.TIP_POST_CLICK)
                         }
                     )
                 }
@@ -290,6 +296,7 @@ private fun HomeRecommendWine(
                             },
                         onShowDetail = {
                             processEvent(HomeContract.Event.ShowWineCardDetail(recommendWines[page].wineId))
+                            AmplitudeProvider.trackEvent(AmplitudeEvent.WINE_DETAIL_CLICK)
                         },
                         color = recommendWines[page].type,
                         name = recommendWines[page].name,

--- a/feature/home/src/main/java/com/teamwiney/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teamwiney/home/HomeScreen.kt
@@ -51,7 +51,7 @@ import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
 import com.teamwiney.analysis.component.TipCard
 import com.teamwiney.core.common.WineyAppState
-import com.teamwiney.core.common.di.AmplitudeProvider
+import com.teamwiney.core.common.AmplitudeProvider
 import com.teamwiney.core.common.navigation.HomeDestinations
 import com.teamwiney.core.design.R
 import com.teamwiney.data.network.model.response.RecommendWine

--- a/feature/home/src/main/java/com/teamwiney/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/teamwiney/home/HomeViewModel.kt
@@ -69,7 +69,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun getRecommendWines() = viewModelScope.launch {
+    private fun getRecommendWines() = viewModelScope.launch {
         wineRepository.getRecommendWines().onStart {
             updateState(currentState.copy(isLoading = true))
         }.collectLatest {
@@ -130,7 +130,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun getWineTips() = viewModelScope.launch {
+    private fun getWineTips() = viewModelScope.launch {
         updateState(
             currentState.copy(
                 wineTips = Pager(


### PR DESCRIPTION
## 변경사항

1.  홈 진입 이벤트 (HOME_ENTER)
2.  와인 상세 페이지 클릭 (WINE_DETAIL_CLICK)
3. "분석하기 버튼" 클릭 (ANALYZE_BUTTON_CLICK)
4. "오늘의 와인 팁 게시물" 클릭 (TIP_POST_CLICK)

해당 이벤트에 대한 이벤트 수집 완료
이벤트 수집은 이벤트가 발생하는 매순간 하도록 설정
-> 이에 대한 필터링은 앰플리튜드 콘솔에서 진행할 것이기 때문

## 논의사항

AmplitudeProvider를 common 모듈에서 관리하는 것이 맞을까?? 아님, app 모듈에서 관리한다음에 각 네비게이션 그래프에 주입을 해줘야할까?